### PR TITLE
Arithmetic evaluation for inequalities, boolean expressions, and ranges / Rewrites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TESTS 		:= $(shell find $(TEST_DIR) -name *.cpp)
 TEST_EXES 	:= $(TESTS:$(TEST_DIR)/%.cpp=$(BUILD_DIR)/%)
 
 DEPFLAGS 	:= -MMD -MP
-CFLAGS 		:= -g -Wall -std=c++17
+CXXFLAGS 	:= -g -O0 -Wall -std=c++17
 LDFLAGS 	:= -lmpfr -lgmp
 
 .PRECIOUS: $(BUILD_DIR)/. $(BUILD_DIR)%/.
@@ -25,7 +25,7 @@ LDFLAGS 	:= -lmpfr -lgmp
 all: build-tests main;
 
 main: $(OBJS)
-	$(CXX) $(CFLAGS) $(OBJS) $(SRC_DIR)/$(ENTRY) $(LDFLAGS) -o $(EXE)
+	$(CXX) $(CXXFLAGS) $(OBJS) $(SRC_DIR)/$(ENTRY) $(LDFLAGS) -o $(EXE)
 
 tests: $(OBJS) $(TEST_EXES)
 	$(TEST_DIR)/test.sh $(TEST_EXES)
@@ -82,13 +82,13 @@ $(BUILD_DIR)%/.:
 	mkdir -p $@
 
 $(BUILD_DIR)/$(LIB_DIR)/%.o: $(LIB_DIR)/%.cpp | $$(@D)/.
-	$(CXX) $(CFLAGS) $(DEPFLAGS) -c -o $@ $< $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) -c -o $@ $< $(LDFLAGS)
 
 $(BUILD_DIR)/$(SRC_DIR)/%.o: $(SRC_DIR)/%.cpp | $$(@D)/.
-	$(CXX) $(CFLAGS) $(DEPFLAGS) -c -o $@ $< $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) -c -o $@ $< $(LDFLAGS)
 
 $(BUILD_DIR)/%: $(TEST_DIR)/%.cpp $(OBJS)
-	$(CXX) $(CFLAGS) $(DEPFLAGS) -o $@ $(OBJS) $< $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(DEPFLAGS) -o $@ $(OBJS) $< $(LDFLAGS)
 
 -include $(DEPS)
 .PHONY: build clean clean-deps clean-all setup tests test-integer test-float test-parser test-sandbox test-integermath test-memcheck

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ test-parser: build/test-parser
 test-arithmetic: build/test-arithmetic
 	$(TEST_DIR)/test.sh build/test-arithmetic
 
+test-inequality: build/test-inequality
+	$(TEST_DIR)/test.sh build/test-inequality
+
 # not tracked
 test-sandbox: build/test-sandbox
 	$(TEST_DIR)/test.sh build/test-sandbox

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ test-arithmetic: build/test-arithmetic
 test-inequality: build/test-inequality
 	$(TEST_DIR)/test.sh build/test-inequality
 
+test-boolean: build/test-boolean
+	$(TEST_DIR)/test.sh build/test-boolean
+
 # not tracked
 test-sandbox: build/test-sandbox
 	$(TEST_DIR)/test.sh build/test-sandbox
@@ -94,4 +97,5 @@ $(BUILD_DIR)/%: $(TEST_DIR)/%.cpp $(OBJS)
 	$(CXX) $(CXXFLAGS) $(DEPFLAGS) -o $@ $(OBJS) $< $(LDFLAGS)
 
 -include $(DEPS)
-.PHONY: build clean clean-deps clean-all setup tests test-integer test-float test-parser test-sandbox test-integermath test-memcheck
+.PHONY: build clean clean-deps clean-all setup tests test-integer test-float test-parser test-sandbox test-integermath test-memcheck \
+		test-boolean

--- a/lib/common/base.h
+++ b/lib/common/base.h
@@ -4,11 +4,11 @@
 #include "error-manager.h"
 #include "util.h"
 
-#define MATHSOLVER_VERSION_STR "0.1.6"
+#define MATHSOLVER_VERSION_STR "0.1.7-dev"
 
 #define MATHSOLVER_VERSION_MAJOR    0
 #define MATHSOLVER_VERSION_MINOR    1
-#define MATHSOLVER_VERSION_PATCH    6
+#define MATHSOLVER_VERSION_PATCH    7
 
 #ifndef MATHSOLVER_RELEASE_BUILD
 #define MATHSOLVER_DEBUG         

--- a/lib/common/base.h
+++ b/lib/common/base.h
@@ -2,6 +2,7 @@
 #define _MATHSOLVER_BASE_H_
 
 #include "error-manager.h"
+#include "util.h"
 
 #define MATHSOLVER_VERSION_STR "0.1.6"
 

--- a/lib/common/error-manager.cpp
+++ b/lib/common/error-manager.cpp
@@ -29,11 +29,20 @@ void ErrorManager::log(const std::string& msg, Type type, const char* file, int 
 
 std::string ErrorManager::toString() const
 {
+    std::list<std::string> all;
     std::string ret;
-    for (auto e : mMessages)    ret += (e + "\n");
-    for (auto e : mWarnings)    ret += (e + "\n");
-    for (auto e : mErrors)      ret += (e + "\n");
-    for (auto e : mFatal)       ret += (e + "\n");
+    
+    all.insert(all.begin(), mFatal.begin(), mFatal.end());
+    all.insert(all.begin(), mErrors.begin(), mErrors.end());
+    all.insert(all.begin(), mWarnings.begin(), mWarnings.end());
+    all.insert(all.begin(), mMessages.begin(), mMessages.end());
+    
+    if (!all.empty())
+    { 
+        ret += all.front();
+        for (auto it = std::next(all.begin()); it != all.end(); ++it)
+            ret += ("\n" + *it);
+    }
 
     return ret;
 }

--- a/lib/common/util.h
+++ b/lib/common/util.h
@@ -1,0 +1,19 @@
+#ifndef _MATHSOLVER_UTIL_H_
+#define _MATHSOLVER_UTIL_H_
+
+namespace MathSolver
+{
+
+template <typename T, typename P, typename Func>   
+T parameterize(P& param, const P& val, const Func& nullary)
+{
+    P& old = param;
+    param = val;
+    T ret = nullary();
+    param = old;
+    return ret;
+}
+
+}
+
+#endif

--- a/lib/eval/arithmetic.cpp
+++ b/lib/eval/arithmetic.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include "arithmetic.h"
+#include "arithrr.h"
 #include "../expr/arithmetic.h"
 #include "../expr/polynomial.h"
 #include "../math/float-math.h"

--- a/lib/eval/arithrr.cpp
+++ b/lib/eval/arithrr.cpp
@@ -288,7 +288,7 @@ ExprNode* rewriteLog(ExprNode* op)
     return op;
 }
 
-ExprNode* rewriteArithmetic(ExprNode* expr)
+ExprNode* rewriteArithmetic(ExprNode* expr, int data)
 {
     if (expr->isNumber())                       return expr;
     if (expr->type() == ExprNode::CONSTANT)     return expr;

--- a/lib/eval/arithrr.cpp
+++ b/lib/eval/arithrr.cpp
@@ -1,0 +1,301 @@
+#include "arithrr.h"
+#include "../expr/polynomial.h"
+
+namespace MathSolver
+{
+
+ExprNode* rewriteNeg(ExprNode* op)
+{
+    if (op->children().size() != 1)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected 1 argument", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    ExprNode* arg = op->children().front();
+    if (isZeroNode(arg))     // (-* 0) ==> 0
+    {
+        ExprNode* ret = new IntNode(0, op->parent());
+        freeExpression(op);
+        op = ret;
+    }
+    else if (arg->isOperator() && ((OpNode*)arg)->name() == "-*") // (-* (-* x)) ==> x
+    {
+        ExprNode* iarg = arg->children().front();
+        arg->children().pop_front();
+        iarg->setParent(op->parent());
+        freeExpression(op);
+        op = iarg;
+    }
+
+    return op;
+}
+
+ExprNode* rewriteAdd(ExprNode* op)
+{   
+    if (op->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    flattenExpr(op);
+    if (isPolynomial(op))  op = reorderPolynomial(op);
+    
+    auto it = op->children().begin();
+    if ((*it)->isOperator() && ((OpNode*)*it)->name() == "-*")        // (+ (-* a) b c ...) ==> (+ (- b a) c ...)
+    {
+        auto it2 = std::next(it); 
+        if ((*it2)->isOperator() && ((OpNode*)*it2)->name() == "-*")    // (+ (-* a) (-* b) c ...) ==> (+ (-* (+ a b)) c ...)
+        {
+            ExprNode* add = new OpNode("+", *it);
+            add->children().push_back((*it)->children().front());
+            add->children().push_back((*it2)->children().front());
+            add = rewriteAdd(add);
+            (*it)->children().clear();
+            (*it2)->children().clear();
+
+            (*it)->children().push_back(add);
+            freeExpression(*it2);
+            op->children().erase(it2);
+        }
+        else              
+        {
+            ((OpNode*)*it)->setName("-");                                              
+            (*it)->children().push_front(*it2);
+            op->children().erase(it2);
+        }
+    }
+
+    while (it != op->children().end())
+    {
+        auto it2 = std::next(it);
+        bool changed = false;
+
+        if (it2 == op->children().end())
+            break;
+
+        if (isZeroNode(*it)) // (+ a 0 b ...) ==> (+ a b ...)
+        {
+            freeExpression(*it);
+            it = op->children().erase(it);
+            changed = true;
+            continue;
+        }
+        else if ((*it2)->isOperator() && ((OpNode*)*it2)->name() == "-*") // (+ a (-* b) c ...) ==> (+ (- a b) c ...)
+        {
+            ((OpNode*)*it2)->setName("-");
+            (*it2)->children().push_front(*it);
+            it = op->children().erase(it);
+            continue;
+        }
+
+        for (; it2 != op->children().end(); ++it2)
+        {
+            if ((*it2)->isOperator() && ((OpNode*)*it2)->name() == "-*" &&  // (+ a b (-* a) c ...) ==> (+ b c ...)
+                eqvExpr(*it, (*it2)->children().front()))
+            {
+                freeExpression(*it);
+                freeExpression(*it2);
+                op->children().erase(it2);
+                it = op->children().erase(it);
+                changed = true;
+                break;
+            }   
+        }
+
+        if (!changed)   ++it;
+    }
+
+    flattenExpr(op);
+    if (op->children().size() < 2) // Post: (+ x) ==> x or (+) ==> 0
+    {
+        ExprNode* ret;
+        if (op->children().size() == 1)     
+        {
+            ret = op->children().front();
+            op->children().clear();
+        }
+        else                                
+        {
+            ret = new IntNode();
+        }
+
+        ret->setParent(op->parent());
+        freeExpression(op);
+        return ret;
+    } 
+
+    return op;
+}
+
+ExprNode* rewriteSub(ExprNode* op)
+{
+    if (op->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    ((OpNode*)op)->setName("+");
+    for (auto it = std::next(op->children().begin()); it != op->children().end(); ++it)
+    {
+        ExprNode* neg = new OpNode("-*", op);
+        neg->children().push_back(*it);
+        neg = rewriteArithmetic(neg);
+        (*it)->setParent(neg);
+        it = replaceChild(op, neg, it);
+    }
+
+    return rewriteAdd(op);
+}
+
+ExprNode* rewriteMul(ExprNode* op)
+{
+    if (op->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    auto it = op->children().begin();
+    while (it != op->children().end())
+    {
+        ExprNode* arg = *it;
+        bool changed = false;
+
+        if (isZeroNode(arg))    // (* a 0 b ...) ==> 0
+        {
+            ExprNode* zero = new IntNode(0, op->parent());
+            freeExpression(op);
+            return zero;
+        }
+
+        if (isIdentityNode(arg))     // (* a 1 b ...) ==> (* a b ...)    
+        {
+            freeExpression(*it);
+            it = op->children().erase(it);
+            changed = true;
+        }
+
+        if (!changed)  ++it;
+    }
+
+    return op;
+}
+
+ExprNode* rewriteDiv(ExprNode* op)
+{
+    if (op->children().size() == 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    ExprNode* num = op->children().front();
+    ExprNode* den = op->children().back();
+
+    if (isZeroNode(num))    // (/ 0 n) ==> 0
+    {
+        ExprNode* zero = new IntNode(0, op->parent());
+        freeExpression(op);
+        return zero;
+    }
+
+    if (isZeroNode(den))    // (/ n 0) ==> undef
+    {
+        ExprNode* ret = new ConstNode("undef", op->parent());
+        gErrorManager.log("Division by zero: " + toInfixString(op), ErrorManager::WARNING);      
+        freeExpression(op);
+        return ret;
+    }
+
+    if (isIdentityNode(den))    // (/ n 1) ==> n
+    {
+        ExprNode* arg = op->children().front();
+        arg->setParent(op->parent());
+        op->children().pop_front();
+        freeExpression(op);
+        return arg;
+    }
+
+    return op;
+}
+
+ExprNode* rewriteExp(ExprNode* op)
+{
+    if (op->children().size() != 1)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected 1 argument", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    ExprNode* arg = op->children().front();
+    if (op->isOperator() && ((OpNode*)op)->name() == "log")  // (exp (log x)) ==> x
+    {
+        ExprNode* iarg = arg->children().front();
+        arg->children().pop_front();
+        iarg->setParent(op->parent());
+        freeExpression(op);
+        return iarg;
+    }
+
+    return op;
+}
+
+ExprNode* rewriteLog(ExprNode* op)
+{
+    if (op->children().size() != 1)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected 1 argument", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    ExprNode* arg = op->children().front();
+    if (op->isOperator() && ((OpNode*)op)->name() == "exp")   // (log (exp x)) ==> x
+    {
+        ExprNode* iarg = arg->children().front();
+        arg->children().pop_front();
+        iarg->setParent(op->parent());
+        freeExpression(op);
+        return iarg;
+    }
+
+    return op;
+}
+
+ExprNode* rewriteArithmetic(ExprNode* expr)
+{
+    if (expr->isNumber())                       return expr;
+    if (expr->type() == ExprNode::CONSTANT)     return expr;
+    if (expr->type() == ExprNode::VARIABLE)     return expr;
+
+    if (expr->isOperator())
+    {
+        OpNode* op = (OpNode*)expr;
+
+        if (op->name() == "-*")                         return rewriteNeg(op);
+        if (op->name() == "+")                          return rewriteAdd(op);
+        if (op->name() == "-")                          return rewriteSub(op);
+        if (op->name() == "*" || op->name() == "**")    return rewriteMul(op);
+        if (op->name() == "/")                          return rewriteDiv(op);
+        if (op->name() == "%" || op->name() == "mod")   return expr; // no rewrite rules
+        if (op->name() == "^")                          return expr; // no rewrite rules
+        if (op->name() == "!")                          return expr; // no rewrite rules
+    }
+    else if (expr->type() == ExprNode::FUNCTION)
+    {
+        FuncNode* func = (FuncNode*)expr;
+        
+        if (func->name() == "exp")              return rewriteExp(expr);
+        if (func->name() == "log")              return rewriteLog(expr);
+        if (func->name() == "sin")              return expr;    // no rewrite rules
+        if (func->name() == "cos")              return expr;    // no rewrite rules
+        if (func->name() == "tan")              return expr;    // no rewrite rules
+    }
+
+    gErrorManager.log("Unimpemented rewrite rule: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
+    return expr;
+}
+    
+} // namespace MathSolver

--- a/lib/eval/arithrr.h
+++ b/lib/eval/arithrr.h
@@ -17,7 +17,8 @@ ExprNode* rewriteExp(ExprNode* op);
 ExprNode* rewriteLog(ExprNode* op);
 
 // Rewrites an expression through rearranging and removing redudant expressions.
-ExprNode* rewriteArithmetic(ExprNode* expr);
+// Second argument is ignored.
+ExprNode* rewriteArithmetic(ExprNode* expr, int data = 0);
 
 }
 

--- a/lib/eval/arithrr.h
+++ b/lib/eval/arithrr.h
@@ -1,0 +1,24 @@
+#ifndef _MATHSOLVER_ARITH_RR_H_
+#define _MATHSOLVER_ARITH_RR_H_
+
+#include "../common/base.h"
+#include "../expr/arithmetic.h"
+
+namespace MathSolver
+{
+
+ExprNode* rewriteNeg(ExprNode* op);
+ExprNode* rewriteAdd(ExprNode* op);
+ExprNode* rewriteSub(ExprNode* op);
+ExprNode* rewriteMul(ExprNode* op);
+ExprNode* rewriteDiv(ExprNode* op);
+
+ExprNode* rewriteExp(ExprNode* op);
+ExprNode* rewriteLog(ExprNode* op);
+
+// Rewrites an expression through rearranging and removing redudant expressions.
+ExprNode* rewriteArithmetic(ExprNode* expr);
+
+}
+
+#endif

--- a/lib/eval/arithrr.h
+++ b/lib/eval/arithrr.h
@@ -12,6 +12,7 @@ ExprNode* rewriteAdd(ExprNode* op);
 ExprNode* rewriteSub(ExprNode* op);
 ExprNode* rewriteMul(ExprNode* op);
 ExprNode* rewriteDiv(ExprNode* op);
+ExprNode* rewritePow(ExprNode* op);
 
 ExprNode* rewriteExp(ExprNode* op);
 ExprNode* rewriteLog(ExprNode* op);

--- a/lib/eval/boolean.cpp
+++ b/lib/eval/boolean.cpp
@@ -1,0 +1,85 @@
+#include <algorithm>
+#include "boolean.h"
+
+namespace MathSolver
+{
+
+ExprNode* booleanNot(ExprNode* expr)
+{
+    if (expr->children().size() != 1)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected 1 argument", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return expr;
+    }    
+
+    if (expr->children().front()->type() != ExprNode::BOOLEAN)
+    {
+        gErrorManager.log("Expected a boolean expression: " + toInfixString(expr),
+                           ErrorManager::ERROR, __FILE__, __LINE__);
+        return expr;
+    }
+
+    ExprNode* res = new BoolNode(!((BoolNode*)expr->children().front())->value(), expr->parent());
+    freeExpression(expr);
+    return res;
+}
+
+ExprNode* booleanBinary(ExprNode* expr, const std::string& op)
+{
+    if (expr->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return expr;
+    }    
+
+    auto pred = [](ExprNode* node) { return node->type() != ExprNode::BOOLEAN; };
+    if (std::any_of(expr->children().begin(), expr->children().end(), pred))
+    {
+        gErrorManager.log("Expected a boolean expression: " + toInfixString(expr),
+                           ErrorManager::ERROR, __FILE__, __LINE__);
+        return expr;
+    }
+
+    bool accum = new BoolNode(((BoolNode*)expr->children().front())->value(), expr->parent());
+    for (auto it = std::next(expr->children().begin()); it != expr->children().end(); ++it)
+    {
+        if (op == "or")          accum = accum || ((BoolNode*)*it)->value();
+        else if (op == "xor")    accum = accum != ((BoolNode*)*it)->value();
+        else if (op == "and")    accum = accum && ((BoolNode*)*it)->value();
+    }        
+
+    ExprNode* res = new BoolNode(accum, expr->parent());
+    freeExpression(expr);
+    return res;
+}
+
+ExprNode* evaluateBooleanExpr(ExprNode* expr, int data)
+{
+    if (expr->type() == ExprNode::BOOLEAN)  return expr;
+
+    if (expr->isOperator())
+    {
+        OpNode* op = (OpNode*)expr;
+        if (op->name() == "not")        return booleanNot(expr);
+        if (op->name() == "or")         return booleanOr(expr);
+        if (op->name() == "xor")        return booleanXor(expr);
+        if (op->name() == "and")        return booleanAnd(expr);
+    }
+
+    gErrorManager.log("Unimpemented operation: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
+    return expr;
+}
+
+bool isBooleanExpr(ExprNode* expr)
+{
+    if (expr->isOperator() && 
+        (((OpNode*)expr)->name() == "not" || ((OpNode*)expr)->name() == "and" ||
+         ((OpNode*)expr)->name() == "or" || ((OpNode*)expr)->name() == "xor"))
+    {
+        return std::all_of(expr->children().begin(), expr->children().end(), isBooleanExpr);
+    }
+
+    return expr->type() == ExprNode::BOOLEAN;
+}
+
+}

--- a/lib/eval/boolean.cpp
+++ b/lib/eval/boolean.cpp
@@ -40,7 +40,7 @@ ExprNode* booleanBinary(ExprNode* expr, const std::string& op)
         return expr;
     }
 
-    bool accum = new BoolNode(((BoolNode*)expr->children().front())->value(), expr->parent());
+    bool accum = ((BoolNode*)expr->children().front())->value();
     for (auto it = std::next(expr->children().begin()); it != expr->children().end(); ++it)
     {
         if (op == "or")          accum = accum || ((BoolNode*)*it)->value();
@@ -55,7 +55,8 @@ ExprNode* booleanBinary(ExprNode* expr, const std::string& op)
 
 ExprNode* evaluateBooleanExpr(ExprNode* expr, int data)
 {
-    if (expr->type() == ExprNode::BOOLEAN)  return expr;
+    if (expr->type() == ExprNode::BOOLEAN)  
+        return expr;
 
     if (expr->isOperator())
     {

--- a/lib/eval/boolean.h
+++ b/lib/eval/boolean.h
@@ -1,0 +1,26 @@
+#ifndef _MATHSOLVER_BOOLEAN_H_
+#define _MATHSOLVER_BOOLEAN_H_
+
+#include "../common/base.h"
+#include "../expr/expr.h"
+
+namespace MathSolver
+{
+
+ExprNode* booleanBinary(ExprNode* expr, const std::string& op);
+
+// Evaluators
+ExprNode* booleanNot(ExprNode* expr);
+inline ExprNode* booleanOr(ExprNode* expr) { return booleanBinary(expr, "or"); }
+inline ExprNode* booleanXor(ExprNode* expr) { return booleanBinary(expr, "xor"); }
+inline ExprNode* booleanAnd(ExprNode* expr) { return booleanBinary(expr, "and"); }
+
+// Evaluates a boolean expression and returns the result.
+ExprNode* evaluateBooleanExpr(ExprNode* expr, int data);
+
+// Returns true if the expression contains only boolean logic.
+bool isBooleanExpr(ExprNode* node);
+
+}
+
+#endif

--- a/lib/eval/evaluator.cpp
+++ b/lib/eval/evaluator.cpp
@@ -7,57 +7,22 @@
 namespace MathSolver
 {
 
-ExprNode* evaluateExprR(ExprNode* expr, bool firstPass)
-{   
-    size_t childCount = expr->children().size();
-    for (size_t i = 0; i < childCount; ++i)
-    {
-        ExprNode* child = expr->children().front();
-        expr->children().pop_front();
-        child = evaluateExprR(child, firstPass);
-        expr->children().push_back(child);
-    }
-  
-    if (isArithmetic(expr))     return evaluateArithmetic(expr, firstPass);
-    if (isRangeExpr(expr))      return evaluateRange(expr);
-
-    gErrorManager.log("Unrecognized expression: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
-    return expr;
-}
-
 ExprNode* evaluateExpr(ExprNode* expr)
 { 
-    if (expr == nullptr)
-        return expr;
-
-    ExprNode* eval = evaluateExprR(expr, true);
-    return evaluateExprR(eval, false);
-}
-
-ExprNode* rewriteExprR(ExprNode* expr)
-{   
-    size_t childCount = expr->children().size();
-    for (size_t i = 0; i < childCount; ++i)
+    if (expr == nullptr)        return expr;
+    
+    if (isArithmetic(expr))
     {
-        ExprNode* child = expr->children().front();
-        expr->children().pop_front();
-        child = rewriteExprR(child);
-        expr->children().push_back(child);
+        expr = evaluateExprLayer(expr, rewriteArithmetic, 0);
+        expr = evaluateExprLayer(expr, evaluateArithmetic, true);
+        return evaluateExprLayer(expr, evaluateArithmetic, false);
     }
-  
-    if (isArithmetic(expr))     return rewriteArithmetic(expr);
-    if (isRangeExpr(expr))      return expr;
+
+    if (isRangeExpr(expr))  return evaluateRange(expr);
+    if (isUndef(expr))      return expr;
 
     gErrorManager.log("Unrecognized expression: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
     return expr;
-}
-
-ExprNode* rewriteExpr(ExprNode* expr)
-{ 
-    if (expr == nullptr)
-        return expr;
-
-    return rewriteExprR(expr);
 }
 
 }

--- a/lib/eval/evaluator.cpp
+++ b/lib/eval/evaluator.cpp
@@ -18,7 +18,7 @@ ExprNode* evaluateExpr(ExprNode* expr)
         return evaluateExprLayer(expr, evaluateArithmetic, false);
     }
 
-    if (isRangeExpr(expr))  return evaluateRange(expr);
+    if (isRangeExpr(expr))  return evaluateExprLayer(expr, evaluateRange, 0);
     if (isUndef(expr))      return expr;
 
     gErrorManager.log("Unrecognized expression: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);

--- a/lib/eval/evaluator.cpp
+++ b/lib/eval/evaluator.cpp
@@ -4,6 +4,7 @@
 #include "boolean.h"
 #include "evaluator.h"
 #include "inequality.h"
+#include "inequalityrr.h"
 #include "interval.h"
 
 namespace MathSolver
@@ -21,8 +22,13 @@ ExprNode* evaluateExpr(ExprNode* expr)
         return evaluateExprLayer(expr, evaluateArithmetic, false);
     }
 
+    if (isInequality(expr))     
+    {
+        expr = evaluateExprLayer(expr, rewriteInequality, 0);
+        return evaluateExprLayer(expr, evaluateInequality, 0);
+    }
+
     if (isBooleanExpr(expr))    return evaluateExprLayer(expr, evaluateBooleanExpr, 0);
-    if (isInequality(expr))     return evaluateExprLayer(expr, evaluateInequality, 0);
     if (isRangeExpr(expr))      return evaluateExprLayer(expr, evaluateRange, 0);
     
     gErrorManager.log("Unrecognized expression: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);

--- a/lib/eval/evaluator.cpp
+++ b/lib/eval/evaluator.cpp
@@ -10,17 +10,19 @@ namespace MathSolver
 ExprNode* evaluateExpr(ExprNode* expr)
 { 
     if (expr == nullptr)        return expr;
-    
+    if (isUndef(expr))          return expr;
+
     if (isArithmetic(expr))
     {
         expr = evaluateExprLayer(expr, rewriteArithmetic, 0);
         expr = evaluateExprLayer(expr, evaluateArithmetic, true);
         return evaluateExprLayer(expr, evaluateArithmetic, false);
     }
-
-    if (isRangeExpr(expr))  return evaluateExprLayer(expr, evaluateRange, 0);
-    if (isUndef(expr))      return expr;
-
+    if (isRangeExpr(expr))  
+    {
+        return evaluateExprLayer(expr, evaluateRange, 0);
+    }
+    
     gErrorManager.log("Unrecognized expression: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
     return expr;
 }

--- a/lib/eval/evaluator.cpp
+++ b/lib/eval/evaluator.cpp
@@ -1,6 +1,7 @@
 #include "../expr/arithmetic.h"
 #include "arithmetic.h"
 #include "arithrr.h"
+#include "boolean.h"
 #include "evaluator.h"
 #include "inequality.h"
 #include "interval.h"
@@ -20,6 +21,7 @@ ExprNode* evaluateExpr(ExprNode* expr)
         return evaluateExprLayer(expr, evaluateArithmetic, false);
     }
 
+    if (isBooleanExpr(expr))    return evaluateExprLayer(expr, evaluateBooleanExpr, 0);
     if (isInequality(expr))     return evaluateExprLayer(expr, evaluateInequality, 0);
     if (isRangeExpr(expr))      return evaluateExprLayer(expr, evaluateRange, 0);
     

--- a/lib/eval/evaluator.cpp
+++ b/lib/eval/evaluator.cpp
@@ -1,5 +1,6 @@
 #include "../expr/arithmetic.h"
 #include "arithmetic.h"
+#include "arithrr.h"
 #include "evaluator.h"
 #include "interval.h"
 
@@ -29,10 +30,34 @@ ExprNode* evaluateExpr(ExprNode* expr)
     if (expr == nullptr)
         return expr;
 
-    ExprNode* simplified = evaluateExprR(expr, true);
-    if (containsType(simplified, ExprNode::FLOAT))
-        return evaluateExprR(simplified, false);
-    return simplified;
+    ExprNode* eval = evaluateExprR(expr, true);
+    return evaluateExprR(eval, false);
+}
+
+ExprNode* rewriteExprR(ExprNode* expr)
+{   
+    size_t childCount = expr->children().size();
+    for (size_t i = 0; i < childCount; ++i)
+    {
+        ExprNode* child = expr->children().front();
+        expr->children().pop_front();
+        child = rewriteExprR(child);
+        expr->children().push_back(child);
+    }
+  
+    if (isArithmetic(expr))     return rewriteArithmetic(expr);
+    if (isRangeExpr(expr))      return expr;
+
+    gErrorManager.log("Unrecognized expression: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
+    return expr;
+}
+
+ExprNode* rewriteExpr(ExprNode* expr)
+{ 
+    if (expr == nullptr)
+        return expr;
+
+    return rewriteExprR(expr);
 }
 
 }

--- a/lib/eval/evaluator.cpp
+++ b/lib/eval/evaluator.cpp
@@ -2,6 +2,7 @@
 #include "arithmetic.h"
 #include "arithrr.h"
 #include "evaluator.h"
+#include "inequality.h"
 #include "interval.h"
 
 namespace MathSolver
@@ -18,10 +19,9 @@ ExprNode* evaluateExpr(ExprNode* expr)
         expr = evaluateExprLayer(expr, evaluateArithmetic, true);
         return evaluateExprLayer(expr, evaluateArithmetic, false);
     }
-    if (isRangeExpr(expr))  
-    {
-        return evaluateExprLayer(expr, evaluateRange, 0);
-    }
+
+    if (isInequality(expr))     return evaluateExprLayer(expr, evaluateInequality, 0);
+    if (isRangeExpr(expr))      return evaluateExprLayer(expr, evaluateRange, 0);
     
     gErrorManager.log("Unrecognized expression: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
     return expr;

--- a/lib/eval/evaluator.h
+++ b/lib/eval/evaluator.h
@@ -6,15 +6,27 @@
 
 namespace MathSolver
 {
+    
+// Templated evaluation layer that takes an expression, an evaluator function, and a data
+// structure or type.
+template <typename Func, typename Data>
+ExprNode* evaluateExprLayer(ExprNode* expr, const Func& func, const Data& data)
+{
+    size_t childCount = expr->children().size();
+    for (size_t i = 0; i < childCount; ++i)
+    {
+        ExprNode* child = expr->children().front();
+        expr->children().pop_front();
+        child = evaluateExprLayer(child, func, data);
+        expr->children().push_back(child);
+    }
+  
+    return func(expr, data);
+}
+
 
 // Evaluates a mathematical expression and returns the result.
 ExprNode* evaluateExpr(ExprNode* expr);
-
-// Simplifies an expression through rewrite rules.
-ExprNode* rewriteExpr(ExprNode* expr);
-
-// Rewrites and then evaluates. This should be called unless you want the rewrite result.
-inline ExprNode* rrAndEvalExpr(ExprNode* expr) { return evaluateExpr(rewriteExpr(expr)); }
 
 }
 

--- a/lib/eval/evaluator.h
+++ b/lib/eval/evaluator.h
@@ -7,8 +7,14 @@
 namespace MathSolver
 {
 
-// Evaluates a mathematical expression. Returns true on success and false otherwise.
+// Evaluates a mathematical expression and returns the result.
 ExprNode* evaluateExpr(ExprNode* expr);
+
+// Simplifies an expression through rewrite rules.
+ExprNode* rewriteExpr(ExprNode* expr);
+
+// Rewrites and then evaluates. This should be called unless you want the rewrite result.
+inline ExprNode* rrAndEvalExpr(ExprNode* expr) { return evaluateExpr(rewriteExpr(expr)); }
 
 }
 

--- a/lib/eval/inequality.cpp
+++ b/lib/eval/inequality.cpp
@@ -1,0 +1,131 @@
+#include <algorithm>
+#include "evaluator.h"
+#include "inequality.h"
+#include "../expr/arithmetic.h"
+
+namespace MathSolver
+{
+
+bool compareNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op)
+{
+    if (lhs->type() == ExprNode::INTEGER && rhs->type() == ExprNode::INTEGER)
+    {
+        if (op == ">")   return ((IntNode*)lhs)->value() > ((IntNode*)rhs)->value();
+        if (op == "<")   return ((IntNode*)lhs)->value() < ((IntNode*)rhs)->value();
+        if (op == ">=")  return ((IntNode*)lhs)->value() >= ((IntNode*)rhs)->value();
+        if (op == "<=")  return ((IntNode*)lhs)->value() <= ((IntNode*)rhs)->value();
+        if (op == ">=")  return ((IntNode*)lhs)->value() >= ((IntNode*)rhs)->value();
+        if (op == ">=")  return ((IntNode*)lhs)->value() != ((IntNode*)rhs)->value();
+    }
+    else
+    {
+        Float f1 = (lhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)lhs)->value().toString()) : ((FloatNode*)lhs)->value();
+        Float f2 = (rhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)rhs)->value().toString()) : ((FloatNode*)rhs)->value();
+        if (op == ">")      return f1 > f2;
+        if (op == "<")      return f1 < f2;
+        if (op == ">=")     return f1 >= f2;
+        if (op == "<=")     return f1 <= f2;
+        if (op == "!=")     return f1 != f2;
+    }
+
+    gErrorManager.log("Expected a comparator " + toInfixString(lhs) + op + toInfixString(rhs), ErrorManager::ERROR, __FILE__, __LINE__);
+    return false;
+}
+
+ExprNode* inequalityCompare(ExprNode* expr, const std::string& op)
+{
+    if (expr->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return expr;
+    }
+
+    bool isValid = true;
+    for (auto it = expr->children().begin(); it != std::prev(expr->children().end()); ++it)
+    {
+        auto it2 = std::next(it);
+        if ((*it)->isNumber() && (*it2)->isNumber() && !compareNumbers(*it, *it2, op))
+            isValid = false;
+    }
+    
+    auto pred = [](ExprNode* node) { return node->isNumber(); };
+    if (std::all_of(expr->children().begin(), expr->children().end(), pred))
+    {
+        ExprNode* node = new BoolNode(isValid, expr->parent());
+        freeExpression(expr);
+        return node;
+    }
+
+    if (!isValid)
+    {
+        ExprNode* node = new BoolNode(false, expr->parent());
+        freeExpression(expr);
+        return node;
+    }
+
+    return expr;
+}
+
+ExprNode* inequalityAnd(ExprNode* expr)
+{
+    if (expr->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return expr;
+    }
+
+    return expr;
+}
+
+ExprNode* inequalityOr(ExprNode* expr)
+{
+    if (expr->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return expr;
+    }
+
+    return expr;
+}
+
+// Evalutator
+
+ExprNode* evaluateInequality(ExprNode* expr, int data)
+{
+    if (expr->isOperator())
+    {
+        OpNode* op = (OpNode*)expr;
+        if (op->name() == ">")          return inequalityGreater(expr);
+        if (op->name() == "<")          return inequalityLess(expr);
+        if (op->name() == ">=")         return inequalityGreaterEq(expr);
+        if (op->name() == "<=")         return inequalityLessEq(expr);
+        if (op->name() == "!=")         return inequalityNotEq(expr);
+
+        if (op->name() == "and")        return inequalityAnd(expr);
+        if (op->name() == "or")         return inequalityOr(expr);
+    }
+
+    if (isArithmetic(expr))     return evaluateExpr(expr);
+
+    gErrorManager.log("Unimpemented operation: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
+    return expr;
+}
+
+// Checking
+
+bool isInequality(ExprNode* expr)
+{
+    if (expr->isOperator())
+    {
+        OpNode* op = (OpNode*)expr;
+        if (op->name() == "and" || op->name() == "or")
+            return std::all_of(op->children().begin(), op->children().end(), isInequality);
+
+        if (op->name() == ">" || op->name() == "<" || op->name() == ">=" || op->name() == "<=" || op->name() == "!=")
+            return std::all_of(op->children().begin(), op->children().end(), isArithmetic);
+    }
+
+    return false;
+}
+
+}

--- a/lib/eval/inequality.cpp
+++ b/lib/eval/inequality.cpp
@@ -1,10 +1,148 @@
 #include <algorithm>
+#include "boolean.h"
 #include "evaluator.h"
 #include "inequality.h"
+#include "../types/range.h"
 #include "../expr/arithmetic.h"
 
 namespace MathSolver
 {
+
+Range extractRange(ExprNode* expr)
+{
+    if (expr->children().size() == 2)
+    {   
+        OpNode* op = (OpNode*)expr;
+        ExprNode* lhs = expr->children().front();
+        ExprNode* rhs = expr->children().back();
+        if (lhs->type() == ExprNode::VARIABLE && rhs->isNumber())
+        {
+            Float bound = toFloat(rhs);
+            if (op->name() == ">")      return Range(bound, "inf", false, false);
+            if (op->name() == "<")      return Range("-inf", bound, false, false);
+            if (op->name() == ">=")     return Range(bound, "inf", true, false);
+            if (op->name() == "<=")     return Range("-inf", bound, false, true);
+            if (op->name() == "!=")     return Range({{ "-inf", bound, false, false }, { bound, "inf", false, false }});
+        }
+        else if (lhs->isNumber() && rhs->type() == ExprNode::VARIABLE)
+        {
+            Float bound = toFloat(lhs);
+            if (op->name() == ">")      return Range("-inf", bound, false, false);
+            if (op->name() == "<")      return Range(bound, "inf", false, false);
+            if (op->name() == ">=")     return Range("-inf", bound, false, true);
+            if (op->name() == "<=")     return Range(bound, "inf", true, false);
+            if (op->name() == "!=")     return Range({{ "-inf", bound, false, false }, { bound, "inf", false, false }});
+        }
+    }   
+    else if (expr->children().size() == 3)
+    {
+        OpNode* op = (OpNode*)expr;
+        ExprNode* lhs = expr->children().front();
+        ExprNode* mid = *(std::next(expr->children().begin()));
+        ExprNode* rhs = expr->children().back();
+        if (lhs->isNumber() && mid->type() == ExprNode::VARIABLE && rhs->isNumber())
+        {
+            Float lbound = toFloat(lhs);
+            Float ubound = toFloat(rhs);
+            if (op->name() == ">")      return Range(ubound, lbound, false, false);
+            if (op->name() == "<")      return Range(lbound, ubound, false, false);
+            if (op->name() == ">=")     return Range(ubound, lbound, true, true);
+            if (op->name() == "<=")     return Range(lbound, ubound, true, true);
+        }
+    }
+    
+    return Range();
+}
+
+ExprNode* toExpression(const interval_t& ival, const std::string& var)
+{
+    VarNode* vnode = new VarNode(var);
+    if (ival.lower == NEG_INFINITY && ival.upper == POS_INFINITY)
+    {
+        ExprNode* op = new OpNode("<");
+        ExprNode* lbound = new FloatNode("-inf", op);
+        ExprNode* ubound = new FloatNode("inf", op);
+        op->children().push_back(lbound);
+        op->children().push_back(vnode);
+        op->children().push_back(ubound);
+        vnode->setParent(op);
+        return op;
+    }
+    else if (ival.lower == NEG_INFINITY)
+    {
+        ExprNode* op = new OpNode(((ival.upperClosed) ? "<=" : "<"));
+        ExprNode* bound = new FloatNode(ival.upper, op);
+        op->children().push_back(vnode);
+        op->children().push_back(bound);
+        vnode->setParent(op);
+        return op;
+    }
+    else if (ival.upper == POS_INFINITY)
+    {
+        ExprNode* op = new OpNode(((ival.lowerClosed) ? ">=" : ">"));
+        ExprNode* bound = new FloatNode(ival.lower, op);
+        op->children().push_back(vnode);
+        op->children().push_back(bound);
+        vnode->setParent(op);
+        return op;
+    }
+    else
+    {
+        if (ival.lowerClosed == ival.upperClosed)
+        {
+            ExprNode* op = new OpNode(((ival.lowerClosed) ? "<=" : "<"));
+            ExprNode* lbound = new FloatNode(ival.lower, op);
+            ExprNode* ubound = new FloatNode(ival.upper, op);
+            op->children().push_back(lbound);
+            op->children().push_back(vnode);
+            op->children().push_back(ubound);
+            vnode->setParent(op);
+            return op;
+        }
+        else
+        {
+            ExprNode* op = new OpNode("and");
+
+            ExprNode* lower = new OpNode(((ival.lowerClosed) ? ">=" : ">"), op);
+            ExprNode* lbound = new FloatNode(ival.lower, op);
+            lower->children().push_back(vnode);
+            lower->children().push_back(lbound);
+            vnode->setParent(lower);
+
+            ExprNode* upper = new OpNode(((ival.upperClosed) ? "<=" : "<"), op);
+            ExprNode* ubound = new FloatNode(ival.upper, op);
+            upper->children().push_back(vnode);
+            upper->children().push_back(ubound);
+            vnode->setParent(upper);
+
+            op->children().push_back(lower);
+            op->children().push_back(upper);
+            return op;
+        }    
+    }
+}
+
+ExprNode* toExpression(const Range& range, const std::string& var)
+{
+    // Workaround for GCC bug 
+    //  Known to exist on 9.3.0 on Ubuntu 20.04 LTS.
+    //  std::distance(list.begin(), list.end()) != list.size()
+    //
+    //  Note that this is not the case in 'inequalityAnd'. Somehow, 'range' is being changed when
+    //  it gets passed by reference.
+    size_t intervalCount = std::distance(range.data().begin(), range.data().end()); 
+
+    if (intervalCount == 0)
+        return new BoolNode(false);
+
+    if (intervalCount == 1)
+        return toExpression(range.data().front(), var);
+    
+    ExprNode* node = new OpNode("and");
+    for (auto e : range.data())
+        node->children().push_back(toExpression(e, var));
+    return node; 
+}
 
 bool compareNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op)
 {
@@ -19,8 +157,8 @@ bool compareNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op)
     }
     else
     {
-        Float f1 = (lhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)lhs)->value().toString()) : ((FloatNode*)lhs)->value();
-        Float f2 = (rhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)rhs)->value().toString()) : ((FloatNode*)rhs)->value();
+        Float f1 = toFloat(lhs);
+        Float f2 = toFloat(rhs);
         if (op == ">")      return f1 > f2;
         if (op == "<")      return f1 < f2;
         if (op == ">=")     return f1 >= f2;
@@ -66,26 +204,101 @@ ExprNode* inequalityCompare(ExprNode* expr, const std::string& op)
     return expr;
 }
 
-ExprNode* inequalityAnd(ExprNode* expr)
+ExprNode* inequalityConnective(ExprNode* expr, const std::string& op)
 {
-    if (expr->children().size() < 2)     
+    auto it = expr->children().begin();
+    while (it != expr->children().end())
     {
-        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
-        return expr;
+        auto it2 = std::next(it);
+        bool changed = false;
+        while (it2 != expr->children().end())
+        {
+            std::list<std::string> lvars = extractVariables(*it);
+            std::list<std::string> rvars = extractVariables(*it2);
+            if (lvars.size() == 1 && rvars.size() == 1 && // (and (x ? a) (x ? b) ...) where a,b are numbers
+                lvars.front() == rvars.front())
+            {
+                Range lhs = extractRange(*it);
+                Range rhs = extractRange(*it2);
+                ExprNode* res;
+                
+                if (op == "and")        res = toExpression(lhs.conjoin(rhs), lvars.front());
+                else if (op == "or")    res = toExpression(lhs.disjoin(rhs), lvars.front());
+                res->setParent(expr);
+
+                freeExpression(*it2);
+                freeExpression(*it);
+                it = expr->children().erase(it);
+                it = expr->children().insert(it, res);
+                it2 = expr->children().erase(it2);   
+            }
+            else
+            {
+                ++it2;
+            }
+        }
+
+        if (!changed) ++it;
     }
 
+    if (expr->children().size() == 1) // ex: (and (x > a)) ==> x
+        return moveNode(expr, expr->children().front());
     return expr;
 }
 
-ExprNode* inequalityOr(ExprNode* expr)
+ExprNode* inequalityAnd(ExprNode* op)
 {
-    if (expr->children().size() < 2)     
+    if (op->children().size() < 2)     
     {
-        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
-        return expr;
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
     }
 
-    return expr;
+    if (isBooleanExpr(op))    return evaluateExpr(op);
+
+    auto it = op->children().begin();
+    while (it != op->children().end())
+    {
+        if ((*it)->type() == ExprNode::BOOLEAN)
+        {
+            if (((BoolNode*)*it)->value())
+            {
+                it = op->children().erase(it);
+            }
+            else
+            {
+                ExprNode* res = new BoolNode(false, op->parent());
+                freeExpression(op);
+                return res;
+            }   
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    return inequalityConnective(op, "and");
+}
+
+ExprNode* inequalityOr(ExprNode* op)
+{
+    if (op->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    if (isBooleanExpr(op))    return evaluateExpr(op);
+
+    auto it = op->children().begin();
+    while (it != op->children().end())
+    {
+        if ((*it)->type() == ExprNode::BOOLEAN)     it = op->children().erase(it); 
+        else ++it;
+    }
+ 
+    return inequalityConnective(op, "or");
 }
 
 // Evalutator

--- a/lib/eval/inequality.h
+++ b/lib/eval/inequality.h
@@ -7,6 +7,16 @@
 namespace MathSolver
 {
 
+// Extracts a Range from an expression of the form (?= x a), (?= a x), or (?= a x b) where 'a', 'b'
+// are numbers and '?=' is a comparator operator. Returns the null set otherwise.
+Range extractRange(ExprNode* expr);
+
+// Converts a univariate interval to an expression.
+ExprNode* toExpression(const interval_t& ival, const std::string& var);
+
+// Converts a univariate Range to an expression.
+ExprNode* toExpression(const Range& range, const std::string& var);
+
 // Returns true if the two numbers satisfy the given comparison.
 bool compareNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op);
 
@@ -23,7 +33,7 @@ ExprNode* inequalityAnd(ExprNode* expr);
 ExprNode* inequalityOr(ExprNode* expr);
 
 // Evaluates an inequality
-ExprNode* evaluateInequality(ExprNode* expr, int data = 0);
+ExprNode* evaluateInequality(ExprNode* expr, int data);
 
 // Returns true if the expression is an inequality.
 bool isInequality(ExprNode* expr);

--- a/lib/eval/inequality.h
+++ b/lib/eval/inequality.h
@@ -21,12 +21,12 @@ ExprNode* toExpression(const Range& range, const std::string& var);
 bool compareNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op);
 
 // Comparator operators
+ExprNode* inequalityNotEq(ExprNode* expr);
 ExprNode* inequalityCompare(ExprNode* expr, const std::string& op);
 inline ExprNode* inequalityGreater(ExprNode* expr) { return inequalityCompare(expr, ">"); }
 inline ExprNode* inequalityLess(ExprNode* expr) { return inequalityCompare(expr, "<"); }
 inline ExprNode* inequalityGreaterEq(ExprNode* expr) { return inequalityCompare(expr, ">="); }
 inline ExprNode* inequalityLessEq(ExprNode* expr) { return inequalityCompare(expr, "<="); }
-inline ExprNode* inequalityNotEq(ExprNode* expr) { return inequalityCompare(expr, "!="); }
 
 // Combine equalities
 ExprNode* inequalityAnd(ExprNode* expr);
@@ -35,8 +35,18 @@ ExprNode* inequalityOr(ExprNode* expr);
 // Evaluates an inequality
 ExprNode* evaluateInequality(ExprNode* expr, int data);
 
+// Returns true if the expression represents a univariate interval, e.g. 0<x<1
+bool isBoundedInequality(ExprNode* expr);
+
+// Returns true if the expression represents a univariate half-bounded
+// interval, e.g. x>1.
+bool isHalfBoundedInequality(ExprNode* expr);
+
 // Returns true if the expression is an inequality.
 bool isInequality(ExprNode* expr);
+
+// Returns true if the node is an inequality node (i.e >, <, >=, <=, !=)
+bool isInequalityNode(ExprNode* expr);
 
 }
 

--- a/lib/eval/inequality.h
+++ b/lib/eval/inequality.h
@@ -1,0 +1,33 @@
+#ifndef _MATHSOLVER_INEQUALITY_
+#define _MATHSOLVER_INEQUALITY_
+
+#include "../common/base.h"
+#include "../expr/expr.h"
+
+namespace MathSolver
+{
+
+// Returns true if the two numbers satisfy the given comparison.
+bool compareNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op);
+
+// Comparator operators
+ExprNode* inequalityCompare(ExprNode* expr, const std::string& op);
+inline ExprNode* inequalityGreater(ExprNode* expr) { return inequalityCompare(expr, ">"); }
+inline ExprNode* inequalityLess(ExprNode* expr) { return inequalityCompare(expr, "<"); }
+inline ExprNode* inequalityGreaterEq(ExprNode* expr) { return inequalityCompare(expr, ">="); }
+inline ExprNode* inequalityLessEq(ExprNode* expr) { return inequalityCompare(expr, "<="); }
+inline ExprNode* inequalityNotEq(ExprNode* expr) { return inequalityCompare(expr, "!="); }
+
+// Combine equalities
+ExprNode* inequalityAnd(ExprNode* expr);
+ExprNode* inequalityOr(ExprNode* expr);
+
+// Evaluates an inequality
+ExprNode* evaluateInequality(ExprNode* expr, int data = 0);
+
+// Returns true if the expression is an inequality.
+bool isInequality(ExprNode* expr);
+
+}
+
+#endif

--- a/lib/eval/inequalityrr.cpp
+++ b/lib/eval/inequalityrr.cpp
@@ -1,0 +1,132 @@
+#include "inequality.h"
+#include "inequalityrr.h"
+
+namespace MathSolver
+{
+
+ExprNode* rewriteInequalityCommon(ExprNode* op)
+{
+    if (op->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected 2 arguments",
+                          ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    if (op->children().size() == 2) 
+    {      
+        if (op->children().front()->isOperator() && ((OpNode*)op->children().front())->name() == "and")
+        {
+            ExprNode* ineq = new OpNode(op->toString(), op->children().front());
+            ExprNode* lhs = copyOf(op->children().front()->children().back()->children().back());
+            ExprNode* rhs = op->children().back();
+
+            op->children().pop_back();
+            lhs->setParent(ineq);
+            rhs->setParent(ineq);
+            ineq->children().push_back(lhs);
+            ineq->children().push_back(rhs);
+            op->children().front()->children().push_back(ineq);
+            return moveNode(op, op->children().front()); // (< (and ...)) ==> (and ...)
+        }
+        else if (isHalfBoundedInequality(op->children().front()))
+        {
+            ExprNode* ineq = new OpNode(op->toString(), op);
+            ExprNode* lhs = copyOf(op->children().front()->children().back());
+            ExprNode* rhs = op->children().back();
+
+            op->children().pop_back();
+            lhs->setParent(ineq);
+            rhs->setParent(ineq);
+            ineq->children().push_back(lhs);
+            ineq->children().push_back(rhs);
+            op->children().push_back(ineq);
+            ((OpNode*)op)->setName("and");
+        }
+
+        return op;
+    }
+
+    ExprNode* res = new OpNode("and", op->parent());
+    auto it = op->children().begin();
+    for (auto it2 = std::next(it); it2 != op->children().end(); ++it, ++it2)
+    {
+        ExprNode* sub = new OpNode(op->toString(), res);
+        sub->children().push_back(copyOf(*it));
+        sub->children().push_back(copyOf(*it2));
+        sub->children().front()->setParent(sub);
+        sub->children().back()->setParent(sub);
+        res->children().push_back(sub);
+    }
+
+    freeExpression(op);
+    return res;
+}
+
+ExprNode* rewriteInequalityNotEq(ExprNode* op)
+{
+    if (op->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+// TODO: 'x < a and x > a' ==> x != a in 'inequality' evaluator
+#ifdef MATHSOLVER_ALLOW_UNSTABLE
+    if (op->children().size() == 2)
+    {
+        ExprNode* var;
+        ExprNode* bound;
+        if (op->children().front()->isNumber())
+        {
+            var = op->children().back();
+            bound = op->children().front();
+        }
+        else
+        {   
+            var = op->children().front();
+            bound = op->children().back();
+        }
+        
+        ExprNode* res = new OpNode("or", op->parent());
+        ExprNode* lhs = new OpNode("<", res);
+        ExprNode* rhs = new OpNode(">", res);
+
+        lhs->children().push_back(copyOf(var));
+        lhs->children().push_back(copyOf(bound));
+        lhs->children().front()->setParent(lhs);
+        lhs->children().back()->setParent(lhs);
+        res->children().push_back(lhs);
+        
+        rhs->children().push_back(copyOf(var));
+        rhs->children().push_back(copyOf(bound));
+        rhs->children().front()->setParent(rhs);
+        rhs->children().back()->setParent(rhs);
+        res->children().push_back(rhs);
+
+        freeExpression(op);
+        return res; 
+    }
+#endif
+
+    // TODO: possibly need to expand into combinations pairs
+    // ex: a != b != c ==> a != b and b != c and a != c
+
+    return op;           
+}
+
+ExprNode* rewriteInequality(ExprNode* expr, int data)
+{
+    if (expr->isOperator())
+    {
+        OpNode* op = (OpNode*)expr;
+        if (op->name() == ">" || op->name() == "<" || op->name() == ">=" || op->name() == "<=")
+            return rewriteInequalityCommon(expr);
+        if (op->name() == "!=")         
+            return rewriteInequalityNotEq(expr);
+    }
+
+    return expr;
+}
+
+}

--- a/lib/eval/inequalityrr.h
+++ b/lib/eval/inequalityrr.h
@@ -1,0 +1,21 @@
+#ifndef _MATHSOLVER_INEQUALITYRR_H_
+#define _MATHSOLVER_INEQUALITYRR_H_
+
+#include "../expr/expr.h"
+
+namespace MathSolver
+{
+
+// Rewrite rule for >, <, >=, <=.
+ExprNode* rewriteInequalityCommon(ExprNode* op);
+
+// Rewrite rule for !=.
+ExprNode* rewriteInequalityNotEq(ExprNode* op);
+
+// Rewrite an inequality expression by expanding chained notation
+// into multiple binary expressions
+ExprNode* rewriteInequality(ExprNode* expr, int data);
+
+}
+
+#endif

--- a/lib/eval/interval.cpp
+++ b/lib/eval/interval.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include "../expr/arithmetic.h"
 #include "evaluator.h"
+#include "inequality.h"
 #include "interval.h"
 
 namespace MathSolver
@@ -59,59 +60,12 @@ ExprNode* rangeSetBuild(ExprNode* op)
 
     if (!isValid)
     {
-        gErrorManager.log("Invalid inequality: " + toInfixString(op), ErrorManager::ERROR);
-        return op;
+        ExprNode* node = new BoolNode(false, op->parent());
+        freeExpression(op);
+        return node;
     }
 
     return op;
-}
-
-bool cmpNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op)
-{
-    if (lhs->type() == ExprNode::INTEGER && rhs->type() == ExprNode::INTEGER)
-    {
-        if (op == ">")   return ((IntNode*)lhs)->value() > ((IntNode*)rhs)->value();
-        if (op == "<")   return ((IntNode*)lhs)->value() < ((IntNode*)rhs)->value();
-        if (op == ">=")  return ((IntNode*)lhs)->value() >= ((IntNode*)rhs)->value();
-        if (op == "<=")  return ((IntNode*)lhs)->value() <= ((IntNode*)rhs)->value();
-        if (op == ">=")  return ((IntNode*)lhs)->value() >= ((IntNode*)rhs)->value();
-        else /* != */    return ((IntNode*)lhs)->value() != ((IntNode*)rhs)->value();
-    }
-
-    Float f1 = (lhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)lhs)->value().toString()) : ((FloatNode*)lhs)->value();
-    Float f2 = (rhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)rhs)->value().toString()) : ((FloatNode*)rhs)->value();
-    if (op == ">")      return f1 > f2;
-    if (op == "<")      return f1 > f2;
-    if (op == ">=")     return f1 > f2;
-    if (op == "<=")     return f1 > f2;
-    else /* != */       return f1 != f2;
-}
-
-ExprNode* rangeCompare(ExprNode* expr, const std::string& op)
-{
-    if (expr->children().size() < 2)     
-    {
-        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
-        return expr;
-    }
-
-    bool validRange = true;
-    for (auto it = expr->children().begin(); it != std::prev(expr->children().end()); ++it)
-    {
-        for (auto it2 = std::next(it); it2 != expr->children().end(); ++it2)
-        {
-            if ((*it)->isNumber() && (*it2)->isNumber() && cmpNumbers(*it, *it2, op))
-                validRange = false;
-        }
-    }
-    
-    if (!validRange)
-    {
-        gErrorManager.log("Invalid inequality: " + toInfixString(expr), ErrorManager::ERROR);
-        return expr;
-    }
-
-    return expr;
 }
 
 //
@@ -127,11 +81,6 @@ ExprNode* evaluateRange(ExprNode* expr, int data)
         OpNode* op = (OpNode*)expr;
         if (op->name() == "or")         return rangeOr(expr);
         if (op->name() == "and")        return rangeAnd(expr);
-        if (op->name() == ">")          return rangeGreater(expr);
-        if (op->name() == "<")          return rangeLess(expr);
-        if (op->name() == ">=")         return rangeGreaterEq(expr);
-        if (op->name() == "<=")         return rangeLessEq(expr);
-        if (op->name() == "!=")         return rangeNotEq(expr);
     }
     else if (expr->isSyntax())
     {
@@ -139,42 +88,28 @@ ExprNode* evaluateRange(ExprNode* expr, int data)
         if (syntax->name() == "|")          return rangeSetBuild(expr);
     }
 
-    if (isArithmetic(expr)) return evaluateExpr(expr);
+    if (isInequality(expr))     return evaluateExpr(expr);
+    if (isArithmetic(expr))     return evaluateExpr(expr);
 
     gErrorManager.log("Unimpemented operation: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
     return expr;
 }
 
-bool isComparatorNode(ExprNode* node)
-{
-    if (!node->isOperator())    return false;
-
-    OpNode* op = (OpNode*)node;
-    return (op->name() == "!=" || op->name() == "==" || 
-            op->name() == ">" || op->name() == "<" || op->name() == ">=" || op->name() == "<=");
-}
-
-bool isRangeExprNode(ExprNode* node)
-{
-    if (node->isOperator())
-    {
-        return ((OpNode*)node)->name() == "or" || ((OpNode*)node)->name() == "and" || isComparatorNode(node);
-    }
-    if (node->isSyntax())
-    {
-        return ((SyntaxNode*)node)->name() == "|" && node->children().front()->type() == ExprNode::VARIABLE &&
-                (isComparatorNode(node->children().back()) || isRangeExprNode(node->children().back()));
-    }
-
-    return node->type() == ExprNode::RANGE;
-}
-
 bool isRangeExpr(ExprNode* expr)
 {
-    if (!isRangeExprNode(expr))   return false;
+    if (expr->isOperator() &&
+        (((OpNode*)expr)->name() == "or" || ((OpNode*)expr)->name() == "and"))
+    {
+        return std::all_of(expr->children().begin(), expr->children().end(), isRangeExpr);
+    }
 
-    auto pred = [](ExprNode* node) { return isRangeExprNode(node) || isArithmetic(node); };
-    return containsAll(expr, pred);
+    if (expr->isSyntax())
+    {
+        return (((SyntaxNode*)expr)->name() == "|" && expr->children().front()->type() == ExprNode::VARIABLE &&
+                isInequality(expr->children().back()));
+    }
+
+    return expr->type() == ExprNode::RANGE;
 }
     
 }

--- a/lib/eval/interval.cpp
+++ b/lib/eval/interval.cpp
@@ -37,7 +37,7 @@ ExprNode* rangeAnd(ExprNode* op)
     return ret;
 }
 
-ExprNode* evaluateRange(ExprNode* expr)
+ExprNode* evaluateRange(ExprNode* expr, int data)
 {
     if (expr->type() == ExprNode::RANGE)        return expr;
 

--- a/lib/eval/interval.cpp
+++ b/lib/eval/interval.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include "../expr/arithmetic.h"
+#include "evaluator.h"
 #include "interval.h"
 
 namespace MathSolver
@@ -37,6 +40,84 @@ ExprNode* rangeAnd(ExprNode* op)
     return ret;
 }
 
+ExprNode* rangeSetBuild(ExprNode* op)
+{
+    if (op->children().size() != 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(op) + " , expected 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return op;
+    }
+
+    std::list<std::string> vars = extractVariables(op->children().back());
+    ExprNode* lhs = op->children().front();
+    bool isValid = true;
+    if (lhs->type() == ExprNode::VARIABLE)
+    {
+        if (std::find(vars.begin(), vars.end(), ((VarNode*)lhs)->name()) == vars.end())
+            isValid = false;
+    }
+
+    if (!isValid)
+    {
+        gErrorManager.log("Invalid inequality: " + toInfixString(op), ErrorManager::ERROR);
+        return op;
+    }
+
+    return op;
+}
+
+bool cmpNumbers(ExprNode* lhs, ExprNode* rhs, const std::string& op)
+{
+    if (lhs->type() == ExprNode::INTEGER && rhs->type() == ExprNode::INTEGER)
+    {
+        if (op == ">")   return ((IntNode*)lhs)->value() > ((IntNode*)rhs)->value();
+        if (op == "<")   return ((IntNode*)lhs)->value() < ((IntNode*)rhs)->value();
+        if (op == ">=")  return ((IntNode*)lhs)->value() >= ((IntNode*)rhs)->value();
+        if (op == "<=")  return ((IntNode*)lhs)->value() <= ((IntNode*)rhs)->value();
+        if (op == ">=")  return ((IntNode*)lhs)->value() >= ((IntNode*)rhs)->value();
+        else /* != */    return ((IntNode*)lhs)->value() != ((IntNode*)rhs)->value();
+    }
+
+    Float f1 = (lhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)lhs)->value().toString()) : ((FloatNode*)lhs)->value();
+    Float f2 = (rhs->type() == ExprNode::INTEGER) ? Float(((IntNode*)rhs)->value().toString()) : ((FloatNode*)rhs)->value();
+    if (op == ">")      return f1 > f2;
+    if (op == "<")      return f1 > f2;
+    if (op == ">=")     return f1 > f2;
+    if (op == "<=")     return f1 > f2;
+    else /* != */       return f1 != f2;
+}
+
+ExprNode* rangeCompare(ExprNode* expr, const std::string& op)
+{
+    if (expr->children().size() < 2)     
+    {
+        gErrorManager.log("Arity mismatch: " + toInfixString(expr) + " , expected at least 2 arguments", ErrorManager::ERROR, __FILE__, __LINE__); 
+        return expr;
+    }
+
+    bool validRange = true;
+    for (auto it = expr->children().begin(); it != std::prev(expr->children().end()); ++it)
+    {
+        for (auto it2 = std::next(it); it2 != expr->children().end(); ++it2)
+        {
+            if ((*it)->isNumber() && (*it2)->isNumber() && cmpNumbers(*it, *it2, op))
+                validRange = false;
+        }
+    }
+    
+    if (!validRange)
+    {
+        gErrorManager.log("Invalid inequality: " + toInfixString(expr), ErrorManager::ERROR);
+        return expr;
+    }
+
+    return expr;
+}
+
+//
+//  Range evaluator
+//
+
 ExprNode* evaluateRange(ExprNode* expr, int data)
 {
     if (expr->type() == ExprNode::RANGE)        return expr;
@@ -46,17 +127,54 @@ ExprNode* evaluateRange(ExprNode* expr, int data)
         OpNode* op = (OpNode*)expr;
         if (op->name() == "or")         return rangeOr(expr);
         if (op->name() == "and")        return rangeAnd(expr);
+        if (op->name() == ">")          return rangeGreater(expr);
+        if (op->name() == "<")          return rangeLess(expr);
+        if (op->name() == ">=")         return rangeGreaterEq(expr);
+        if (op->name() == "<=")         return rangeLessEq(expr);
+        if (op->name() == "!=")         return rangeNotEq(expr);
     }
+    else if (expr->isSyntax())
+    {
+        SyntaxNode* syntax = (SyntaxNode*)expr;
+        if (syntax->name() == "|")          return rangeSetBuild(expr);
+    }
+
+    if (isArithmetic(expr)) return evaluateExpr(expr);
 
     gErrorManager.log("Unimpemented operation: " + toInfixString(expr), ErrorManager::ERROR, __FILE__, __LINE__);
     return expr;
 }
 
+bool isComparatorNode(ExprNode* node)
+{
+    if (!node->isOperator())    return false;
+
+    OpNode* op = (OpNode*)node;
+    return (op->name() == "!=" || op->name() == "==" || 
+            op->name() == ">" || op->name() == "<" || op->name() == ">=" || op->name() == "<=");
+}
+
 bool isRangeExprNode(ExprNode* node)
 {
     if (node->isOperator())
-        return ((OpNode*)node)->name() == "or" || ((OpNode*)node)->name() == "and";
+    {
+        return ((OpNode*)node)->name() == "or" || ((OpNode*)node)->name() == "and" || isComparatorNode(node);
+    }
+    if (node->isSyntax())
+    {
+        return ((SyntaxNode*)node)->name() == "|" && node->children().front()->type() == ExprNode::VARIABLE &&
+                (isComparatorNode(node->children().back()) || isRangeExprNode(node->children().back()));
+    }
+
     return node->type() == ExprNode::RANGE;
+}
+
+bool isRangeExpr(ExprNode* expr)
+{
+    if (!isRangeExprNode(expr))   return false;
+
+    auto pred = [](ExprNode* node) { return isRangeExprNode(node) || isArithmetic(node); };
+    return containsAll(expr, pred);
 }
     
 }

--- a/lib/eval/interval.h
+++ b/lib/eval/interval.h
@@ -12,27 +12,16 @@ ExprNode* rangeOr(ExprNode* op);
 ExprNode* rangeAnd(ExprNode* op);
 ExprNode* rangeSetBuild(ExprNode* op);
 
-// Comparator operators
-ExprNode* rangeCompare(ExprNode* expr, const std::string& op);
-inline ExprNode* rangeGreater(ExprNode* expr) { return rangeCompare(expr, ">"); }
-inline ExprNode* rangeLess(ExprNode* expr) { return rangeCompare(expr, ">="); }
-inline ExprNode* rangeGreaterEq(ExprNode* expr) { return rangeCompare(expr, ">"); }
-inline ExprNode* rangeLessEq(ExprNode* expr) { return rangeCompare(expr, "<="); }
-inline ExprNode* rangeNotEq(ExprNode* expr) { return rangeCompare(expr, "!="); }
-
 // Evaluates the given Range expression and returns the result.
 ExprNode* evaluateRange(ExprNode* expr, int data = 0);
 
 // Returns true if the node is a comparator.
 bool isComparatorNode(ExprNode* node);
 
-// Returns true if the node is:
-//  (i)     a Range type
-//  (ii)    'or', 'and'
-//  (iii)   comparison (e.g. x > 5)
-bool isRangeExprNode(ExprNode* node);
-
 // Returns true if the expression can be simplified into a range.
+//  (i)     Range type, e.g. [0, 1]
+//  (ii)    'or', 'and'
+//  (iii)   Set builder, e.g. { x | x > 5 }  
 bool isRangeExpr(ExprNode* expr);
 
 }

--- a/lib/eval/interval.h
+++ b/lib/eval/interval.h
@@ -8,7 +8,7 @@ namespace MathSolver
 {
 
 // Evaluates the given Range expression and returns the result.
-ExprNode* evaluateRange(ExprNode* expr);
+ExprNode* evaluateRange(ExprNode* expr, int data = 0);
 
 // Returns true if the node is:
 //  (i) a Range type

--- a/lib/eval/interval.h
+++ b/lib/eval/interval.h
@@ -7,16 +7,33 @@
 namespace MathSolver
 {
 
+// Range operators
+ExprNode* rangeOr(ExprNode* op);
+ExprNode* rangeAnd(ExprNode* op);
+ExprNode* rangeSetBuild(ExprNode* op);
+
+// Comparator operators
+ExprNode* rangeCompare(ExprNode* expr, const std::string& op);
+inline ExprNode* rangeGreater(ExprNode* expr) { return rangeCompare(expr, ">"); }
+inline ExprNode* rangeLess(ExprNode* expr) { return rangeCompare(expr, ">="); }
+inline ExprNode* rangeGreaterEq(ExprNode* expr) { return rangeCompare(expr, ">"); }
+inline ExprNode* rangeLessEq(ExprNode* expr) { return rangeCompare(expr, "<="); }
+inline ExprNode* rangeNotEq(ExprNode* expr) { return rangeCompare(expr, "!="); }
+
 // Evaluates the given Range expression and returns the result.
 ExprNode* evaluateRange(ExprNode* expr, int data = 0);
 
+// Returns true if the node is a comparator.
+bool isComparatorNode(ExprNode* node);
+
 // Returns true if the node is:
-//  (i) a Range type
-//  (ii) 'or', 'and'
+//  (i)     a Range type
+//  (ii)    'or', 'and'
+//  (iii)   comparison (e.g. x > 5)
 bool isRangeExprNode(ExprNode* node);
 
 // Returns true if the expression can be simplified into a range.
-inline bool isRangeExpr(ExprNode* expr) { return containsAll(expr, isRangeExprNode); }
+bool isRangeExpr(ExprNode* expr);
 
 }
 

--- a/lib/expr/arithmetic.cpp
+++ b/lib/expr/arithmetic.cpp
@@ -91,16 +91,30 @@ std::list<ExprNode*> coeffTerm(ExprNode* expr, ExprNode* term)
     return coeff;
 }
 
-ExprNode* getPowBase(ExprNode* op)
+
+ExprNode* extractPowBase(ExprNode* op)
 {
-    if (op->isOperator() && ((OpNode*)op)->name() == "^")       return op->children().front();
-    else                                                        return op;
+    if (op->isOperator() && ((OpNode*)op)->name() == "^")    return copyOf(op->children().front());
+    else                                                     return copyOf(op);
 }
 
-ExprNode* getPowExp(ExprNode* op)
+ExprNode* extractPowExp(ExprNode* op)
 {
+    if (op->isOperator() && ((OpNode*)op)->name() == "^")    return copyOf(op->children().back());
+    else                                                     return new IntNode(1);
+}
+
+ExprNode* peekPowBase(ExprNode* op)
+{
+    if (op->isOperator() && ((OpNode*)op)->name() == "^")    return op->children().front();
+    else                                                     return op;
+}
+
+ExprNode* peekPowExp(ExprNode* op)
+{
+    static IntNode one = IntNode(1); // TODO: definitely bad
     if (op->isOperator() && ((OpNode*)op)->name() == "^")       return op->children().back();
-    else                                                        return new IntNode(1);
+    else                                                        return &one;
 }
 
 void arithmeticRewrite(ExprNode* op)

--- a/lib/expr/arithmetic.cpp
+++ b/lib/expr/arithmetic.cpp
@@ -154,20 +154,4 @@ ExprNode* peekPowExp(ExprNode* op)
     else                                                        return &one;
 }
 
-void arithmeticRewrite(ExprNode* op)
-{
-    if (op->isOperator() && ((OpNode*)op)->name() == "-")
-    {
-        ((OpNode*)op)->setName("+");
-        for (auto it = std::next(op->children().begin()); it != op->children().end(); ++it)
-        {
-            ExprNode* neg = new OpNode("-*", op);
-            neg->children().push_back(*it);
-            (*it)->setParent(neg);
-            it = replaceChild(op, neg, it);
-        }
-        flattenExpr(op);
-    }
-}
-
 }

--- a/lib/expr/arithmetic.cpp
+++ b/lib/expr/arithmetic.cpp
@@ -3,11 +3,11 @@
 namespace MathSolver
 {
 
-bool nodeIsArithmetic(ExprNode* node)
+bool isArithmeticNode(ExprNode* node)
 {
     if (node->type() == ExprNode::FUNCTION)
     {
-        FuncNode* func = (FuncNode*)node;
+        FuncNode* func = (FuncNode*)node;   // TODO: move these functions out
         return (func->name() == "exp" || func->name() == "log" ||
                 func->name() == "sin" || func->name() == "cos" || func->name() == "tan");
     }

--- a/lib/expr/arithmetic.h
+++ b/lib/expr/arithmetic.h
@@ -26,6 +26,9 @@ std::list<ExprNode*> commonTerm(ExprNode* expr1, ExprNode* expr2);
 // Finds the coefficient of an expression given a base term.
 std::list<ExprNode*> coeffTerm(ExprNode* expr, ExprNode* term);
 
+// Removes a list of term from an expression
+void removeTerm(ExprNode* expr, const std::list<ExprNode*>& terms);
+
 // Assumes the expression is in the form x^n or x and returns a copy of x,
 ExprNode* extractPowBase(ExprNode* op);
 

--- a/lib/expr/arithmetic.h
+++ b/lib/expr/arithmetic.h
@@ -44,10 +44,6 @@ ExprNode* peekPowBase(ExprNode* op);
 // Assumes the expression is in the form x^n or x and returns n or 1 directly.
 ExprNode* peekPowExp(ExprNode* op);
 
-// Applies arithmetic rewrite rules to make evaluation easier
-//   (- a b c ...) ==> (+ a (- b) (- c) ...)
-void arithmeticRewrite(ExprNode* op);
-
 }
 
 #endif

--- a/lib/expr/arithmetic.h
+++ b/lib/expr/arithmetic.h
@@ -20,6 +20,9 @@ inline bool isArithmetic(ExprNode* expr) { return containsAll(expr, nodeIsArithm
 // Returns true if the expression contains inexact (Float) subexpressions.
 inline bool isInexact(ExprNode* expr) { return containsAll(expr, [](ExprNode* node) { return node->type() != ExprNode::FLOAT; }); }
 
+// Returns true if the expression is undefined
+inline bool isUndef(ExprNode* expr) { return expr->type() == ExprNode::CONSTANT && ((ConstNode*)expr)->name() == "undef"; }
+
 // Finds the common term between two monomial expressions.
 std::list<ExprNode*> commonTerm(ExprNode* expr1, ExprNode* expr2);
 

--- a/lib/expr/arithmetic.h
+++ b/lib/expr/arithmetic.h
@@ -26,13 +26,17 @@ std::list<ExprNode*> commonTerm(ExprNode* expr1, ExprNode* expr2);
 // Finds the coefficient of an expression given a base term.
 std::list<ExprNode*> coeffTerm(ExprNode* expr, ExprNode* term);
 
-// Assumes the expression is in the form x^n or x and returns x, the base that is being
-// raised to the power of n or 1, respectively.
-ExprNode* getPowBase(ExprNode* op);
+// Assumes the expression is in the form x^n or x and returns a copy of x,
+ExprNode* extractPowBase(ExprNode* op);
 
-// Assumes the expression is in the form x^n or x and returns n or 1, respectively. If it is the
-// latter case, a new expression node is created.
-ExprNode* getPowExp(ExprNode* op);
+// Assumes the expression is in the form x^n or x and returns a copy of n or 1, respectively.
+ExprNode* extractPowExp(ExprNode* op);
+
+// Assumes the expression is in the form x^n or x and returns x directly.
+ExprNode* peekPowBase(ExprNode* op);
+
+// Assumes the expression is in the form x^n or x and returns n or 1 directly.
+ExprNode* peekPowExp(ExprNode* op);
 
 // Applies arithmetic rewrite rules to make evaluation easier
 //   (- a b c ...) ==> (+ a (- b) (- c) ...)

--- a/lib/expr/arithmetic.h
+++ b/lib/expr/arithmetic.h
@@ -12,10 +12,10 @@ namespace MathSolver
 //      operators: +, -, *, /, % (mod), !, ^
 //      functions: exp, log, sin, cos, tan
 // Assumes the expression is valid.
-bool nodeIsArithmetic(ExprNode* node);
+bool isArithmeticNode(ExprNode* node);
 
 // Returns true if every node in the expression is arithmetic:
-inline bool isArithmetic(ExprNode* expr) { return containsAll(expr, nodeIsArithmetic); }
+inline bool isArithmetic(ExprNode* expr) { return containsAll(expr, isArithmeticNode); }
 
 // Returns true if the expression contains inexact (Float) subexpressions.
 inline bool isInexact(ExprNode* expr) { return containsAll(expr, [](ExprNode* node) { return node->type() != ExprNode::FLOAT; }); }

--- a/lib/expr/expr.cpp
+++ b/lib/expr/expr.cpp
@@ -6,8 +6,8 @@
 namespace MathSolver
 {
 
-const size_t FLATTENABLE_OP_COUNT = 4;
-const std::string FLATTENABLE_OPS[FLATTENABLE_OP_COUNT] = { "+", "-", "*", "**" };
+const size_t FLATTENABLE_OP_COUNT = 8;
+const std::string FLATTENABLE_OPS[FLATTENABLE_OP_COUNT] = { "+", "-", "*", "**", ">", "<", ">=", "<=" };
 
 ExprNode* copyOf(ExprNode* expr)
 {
@@ -53,6 +53,20 @@ bool eqvExpr(ExprNode* a, ExprNode* b)
 	}
 
 	return false;
+}
+
+std::list<std::string> extractVariables(ExprNode* expr)
+{
+	std::list<std::string> ret;
+	for (auto e : expr->children())
+	{
+		std::list<std::string> sub = extractVariables(e);
+		ret.insert(ret.end(), sub.begin(), sub.end());
+	}
+
+	if (expr->type() == ExprNode::VARIABLE)
+		ret.push_back(expr->toString());
+	return ret;
 }
 
 void flattenExpr(ExprNode* expr)
@@ -166,10 +180,16 @@ std::string toInfixString(ExprNode* expr)
 		}
 		
 	}
-	else
+	else if (expr->isSyntax())
 	{
-		return expr->toString();
+		SyntaxNode* syntax = (SyntaxNode*)expr;
+		if (syntax->name() == "|")
+		{
+			return "{ " + toInfixString(expr->children().front()) + " " + syntax->name() + " " + toInfixString(expr->children().back()) + " }";
+		}
 	}
+
+	return expr->toString();
 }
 
 std::string toPrefixString(ExprNode* expr)

--- a/lib/expr/expr.cpp
+++ b/lib/expr/expr.cpp
@@ -143,7 +143,10 @@ std::string toInfixString(ExprNode* expr)
 		}
 		else if (op->name() == "^")
 		{
-			return toInfixString(op->children().front()) + "^" + toInfixString(op->children().back());
+			if (op->parent() != nullptr && op->parent()->prec() > op->prec())
+				return toInfixString(op->children().front()) + "^(" + toInfixString(op->children().back()) + ")";
+			else
+				return toInfixString(op->children().front()) + "^" + toInfixString(op->children().back());
 		}
 		else if (op->name() == "mod" || op->name() == "or" || op->name() == "and")
 		{

--- a/lib/expr/expr.cpp
+++ b/lib/expr/expr.cpp
@@ -143,10 +143,7 @@ std::string toInfixString(ExprNode* expr)
 		}
 		else if (op->name() == "^")
 		{
-			if (op->parent() != nullptr && op->parent()->prec() > op->prec())
-				return toInfixString(op->children().front()) + "^(" + toInfixString(op->children().back()) + ")";
-			else
-				return toInfixString(op->children().front()) + "^" + toInfixString(op->children().back());
+			return toInfixString(op->children().front()) + "^" + toInfixString(op->children().back());		
 		}
 		else if (op->name() == "mod" || op->name() == "or" || op->name() == "and")
 		{

--- a/lib/expr/expr.cpp
+++ b/lib/expr/expr.cpp
@@ -173,7 +173,7 @@ std::string toInfixString(ExprNode* expr)
 			std::string printOp = (op->name() == "**") ? "" : ((op->name() == "-*") ? "-" : op->name());
 			for (auto it = std::next(op->children().begin()); it != op->children().end(); ++it)
 				sub += (printOp + toInfixString(*it));
-			if (op->parent() != nullptr && op->parent()->prec() < op->prec())
+			if (op->parent() != nullptr && !op->parent()->isSyntax() && op->parent()->prec() < op->prec())
 				return "(" + sub + ")";
 			else
 				return sub;

--- a/lib/expr/expr.h
+++ b/lib/expr/expr.h
@@ -38,6 +38,9 @@ ExprNode* copyOf(ExprNode* expr);
 // Returns true if the value of two nodes is the same.
 bool eqvExpr(ExprNode* a, ExprNode* b);
 
+// Returns a list of variable names in an expression
+std::list<std::string> extractVariables(ExprNode* expr);
+
 // Takes an expression node and recursively simplifes certain operators with interior nodes of the
 // same operator into a single operator with many operands. e.g. (+ (+ a (+ b c)) d) ==> (+ a b c d)
 void flattenExpr(ExprNode* expr);

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -84,6 +84,13 @@ RangeNode::RangeNode(Range&& data, ExprNode* parent)
     mPrec = 0;
 }
 
+BoolNode::BoolNode(bool data, ExprNode* parent)
+{
+    mData = data;
+    mParent = parent;
+    mPrec = 0;
+}
+
 bool isZeroNode(ExprNode* expr)
 {
     return ((expr->type() == ExprNode::INTEGER && ((IntNode*)expr)->value().isZero()) || 

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -136,6 +136,12 @@ const std::string OPERATORS[OPERATOR_COUNT] =
     "not", "or", "xor", "and"
 };
 
+const size_t CONSTANT_COUNT = 2;
+const std::string CONSTANTS[CONSTANT_COUNT] = 
+{
+    "e", "pi"
+};
+
 bool isOperator(char c)
 {
 	for (size_t i = 0; OPERATOR_CHARS[i]; ++i)
@@ -176,24 +182,17 @@ bool isOpeningBracket(const std::string& str)
 
 bool isFunction(const std::string& func)
 {
-	for (size_t i = 0; i < PREDEF_FUNC_COUNT; ++i)
-	{
-		if (func == PREDEF_FUNCTIONS[i])
-			return true;
-	}
-
-	return false;
+	return isMember(PREDEF_FUNCTIONS, PREDEF_FUNC_COUNT, func);
 }
 
 bool isOperator(const std::string& op)
 {
-    for (size_t i = 0; i < OPERATOR_COUNT; ++i)
-    {
-        if (op == OPERATORS[i])
-            return true;
-    }
+    return isMember(OPERATORS, OPERATOR_COUNT, op);
+}
 
-    return false;
+bool isConstant(const std::string& val)
+{
+    return isMember(CONSTANTS, CONSTANT_COUNT, val);
 }
 
 int opPrec(const std::string& str)

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -125,13 +125,14 @@ const std::string PREDEF_FUNCTIONS[PREDEF_FUNC_COUNT] =
 	"sin", "cos", "tan"
 };
 
-const size_t OPERATOR_COUNT = 19;
+const size_t OPERATOR_COUNT = 20;
 const std::string OPERATORS[OPERATOR_COUNT] = 
 {
 	"+", "-", "*", "/", "%", "mod",
     "-*", "**",
 	"^", "!",
-	">", "<", ">=", "<=", "=",
+	">", "<", ">=", "<=", "!=",
+    "=",
     "not", "or", "xor", "and"
 };
 
@@ -204,8 +205,9 @@ int opPrec(const std::string& str)
 	else if (str == "*" || str == "/" || str == "%")		return 6;
     else if (str == "mod")								    return 6;
 	else if (str == "+" || str == "-")					    return 7;
-	else if (str == ">" || str == ">=" || str == "=" ||
-			 str == "<" || str == "<=")					    return 8;
+	else if (str == ">" || str == ">=" ||
+			 str == "<" || str == "<=" ||
+             str == "=" || str == "!=")					    return 8;
     else if (str == "not" || str == "and" ||
              str == "or" ||  str == "xor")                  return 9;
 	else												    return 0;

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -98,6 +98,7 @@ bool isIdentityNode(ExprNode* expr)
 
 
 const char* OPERATOR_CHARS = "+-*/%^!=><|";
+const char* SYNTAX_CHARS = "(){}[]|,";
 
 const size_t PREDEF_FUNC_COUNT = 5;
 const std::string PREDEF_FUNCTIONS[PREDEF_FUNC_COUNT] = 
@@ -127,10 +128,31 @@ bool isOperator(char c)
 	return false;
 }
 
+bool isSyntax(char c)
+{
+	for (size_t i = 0; SYNTAX_CHARS[i]; ++i)
+	{
+		if (c == SYNTAX_CHARS[i])
+			return true;
+	}
+
+	return false;
+}
+
 bool isBracket(char c)
 {
 	return (c == '(' || c == '{' || c == '[' ||
 			c == ')' || c == '}' || c == ']');
+}
+
+bool isClosingBracket(const std::string& str)
+{
+    return (str == ")" || str == "}" || str == "]");
+}
+
+bool isOpeningBracket(const std::string& str)
+{
+    return (str == "(" || str == "{" || str == "[");
 }
 
 bool isFunction(const std::string& func)

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -84,6 +84,19 @@ RangeNode::RangeNode(Range&& data, ExprNode* parent)
     mPrec = 0;
 }
 
+bool isZeroNode(ExprNode* expr)
+{
+    return ((expr->type() == ExprNode::INTEGER && ((IntNode*)expr)->value().isZero()) || 
+            (expr->type() == ExprNode::FLOAT && ((FloatNode*)expr)->value().isZero()));
+}
+
+bool isIdentityNode(ExprNode* expr)
+{
+    return ((expr->type() == ExprNode::INTEGER && ((IntNode*)expr)->value() == Integer(1)) || 
+            (expr->type() == ExprNode::FLOAT && ((FloatNode*)expr)->value() == Float("1.0")));
+}
+
+
 const char* OPERATOR_CHARS = "+-*/%^!=><|";
 
 const size_t PREDEF_FUNC_COUNT = 5;

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -103,6 +103,17 @@ bool isIdentityNode(ExprNode* expr)
             (expr->type() == ExprNode::FLOAT && ((FloatNode*)expr)->value() == Float("1.0")));
 }
 
+Float toFloat(ExprNode* node)
+{
+    if (!node->isNumber())
+    {
+        gErrorManager.log("Only numerical nodes can be converted into a Float: " + node->toString(),
+                          ErrorManager::ERROR, __FILE__, __LINE__);
+        return Float();
+    }
+
+    return (node->type() == ExprNode::INTEGER) ? Float(((IntNode*)node)->value().toString()) : ((FloatNode*)node)->value();    
+}
 
 const char* OPERATOR_CHARS = "+-*/%^!=><|";
 const char* SYNTAX_CHARS = "(){}[]|,";
@@ -114,14 +125,14 @@ const std::string PREDEF_FUNCTIONS[PREDEF_FUNC_COUNT] =
 	"sin", "cos", "tan"
 };
 
-const size_t OPERATOR_COUNT = 17;
+const size_t OPERATOR_COUNT = 19;
 const std::string OPERATORS[OPERATOR_COUNT] = 
 {
 	"+", "-", "*", "/", "%", "mod",
     "-*", "**",
 	"^", "!",
 	">", "<", ">=", "<=", "=",
-    "or", "and"
+    "not", "or", "xor", "and"
 };
 
 bool isOperator(char c)
@@ -195,7 +206,8 @@ int opPrec(const std::string& str)
 	else if (str == "+" || str == "-")					    return 7;
 	else if (str == ">" || str == ">=" || str == "=" ||
 			 str == "<" || str == "<=")					    return 8;
-    else if (str == "or" || str == "and")                   return 9;
+    else if (str == "not" || str == "and" ||
+             str == "or" ||  str == "xor")                  return 9;
 	else												    return 0;
 }
 

--- a/lib/expr/node.h
+++ b/lib/expr/node.h
@@ -25,7 +25,8 @@ public:
         INTEGER,
         FLOAT,
         RANGE,
-        SYNTAX
+        SYNTAX,
+        BOOLEAN
     };
 
 public:
@@ -283,6 +284,30 @@ public:
 
 private:
     Range mData;
+};
+
+// Boolean node
+class BoolNode : public ExprNode
+{
+public:
+    BoolNode(bool data, ExprNode* parent = nullptr);
+    ~BoolNode() {}
+
+    inline bool value() const { return mData; }
+
+    inline bool isNumber() const { return false; }
+    inline bool isOperator() const { return false; }
+    inline bool isSyntax() const { return false; }
+    inline bool isValue() const { return true; }
+
+    inline void setValue(bool b) { mData = b; }
+
+    inline std::string toString() const { return (mData) ? "true" : "false"; }
+ 
+    inline Type type() const { return BOOLEAN; }
+
+private:
+    bool mData;
 };
 
 //

--- a/lib/expr/node.h
+++ b/lib/expr/node.h
@@ -286,7 +286,19 @@ private:
 };
 
 //
-// Parsing
+//  Special nodes
+//
+
+// Returns true if the expression node represents a zero value in the context
+// of the type.
+bool isZeroNode(ExprNode* expr);
+
+// Returns true if the expression node represents a one, identity, or unit value
+// depending on the context of the type.
+bool isIdentityNode(ExprNode* expr);
+
+//
+// Parsing (TODO: move to parsing?)
 //
 
 // Returns true if the character is an operator.
@@ -319,6 +331,8 @@ bool isOperator(const std::string& op);
 // Returns the precedence of the string
 int opPrec(const std::string& str);
 
+
+
 //
 // Node manipulation
 //
@@ -335,7 +349,6 @@ std::list<ExprNode*>::iterator replaceChild(ExprNode* parent, ExprNode* src, std
 // Removes this expression from the parent's list of children. Assumes another pointer is tracking this node,
 // else data will be lost.
 void releaseChild(ExprNode* node);
-
 
 
 }

--- a/lib/expr/node.h
+++ b/lib/expr/node.h
@@ -329,6 +329,19 @@ Float toFloat(ExprNode* node);
 // Parsing (TODO: move to parsing?)
 //
 
+// Returns true if the 'val' is in the array
+template <typename T>
+bool isMember(const T* array, size_t size, const T& val)
+{
+    for (size_t i = 0; i < size; ++i)
+    {
+        if (val == array[i])
+            return true;
+    }
+
+    return false;
+}
+
 // Returns true if the character is an operator.
 bool isOperator(char c);
 
@@ -349,6 +362,9 @@ bool isFunction(const std::string& func);
 
 // Returns true if the string is an operator
 bool isOperator(const std::string& op);
+
+// Returns true if the string is a constant
+bool isConstant(const std::string& op);
 
 /*
     Operator precedence

--- a/lib/expr/node.h
+++ b/lib/expr/node.h
@@ -304,8 +304,17 @@ bool isIdentityNode(ExprNode* expr);
 // Returns true if the character is an operator.
 bool isOperator(char c);
 
+// Returns true if the character is syntax
+bool isSyntax(char c);
+
 // Returns true if the character is a bracket: (), {}, [].
 bool isBracket(char c);
+
+// Returns true if the string is a bracket: ),},]
+bool isClosingBracket(const std::string& str);
+
+// Returns true if the string is a bracket: (,{,[
+bool isOpeningBracket(const std::string& str);
 
 // Returns true if the string is a predefined or user-defined function.
 bool isFunction(const std::string& func);
@@ -330,8 +339,6 @@ bool isOperator(const std::string& op);
 
 // Returns the precedence of the string
 int opPrec(const std::string& str);
-
-
 
 //
 // Node manipulation

--- a/lib/expr/node.h
+++ b/lib/expr/node.h
@@ -322,6 +322,9 @@ bool isZeroNode(ExprNode* expr);
 // depending on the context of the type.
 bool isIdentityNode(ExprNode* expr);
 
+// Returns the floating-point value of this node. Must be a number or an error will be generated.
+Float toFloat(ExprNode* node);
+
 //
 // Parsing (TODO: move to parsing?)
 //

--- a/lib/expr/parser.cpp
+++ b/lib/expr/parser.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include "parser.h"
 
@@ -123,9 +124,24 @@ bool bracketedExpr(std::list<ExprNode*>::iterator begin, std::list<ExprNode*>::i
 
 ExprNode* captureDataType(std::list<ExprNode*>::iterator begin, std::list<ExprNode*>::iterator end)
 {
+    auto isBar = [](ExprNode* node) { return (node->isSyntax() && ((SyntaxNode*)node)->name() == "|"); };
+    auto barIt = std::find_if(begin, end, isBar);
+
+    if (std::find_if(std::next(barIt), end, isBar) == end)
+    {
+        ExprNode* bar = *barIt;
+        ExprNode* key = parseTokensR(begin, barIt);
+        ExprNode* val = parseTokensR(std::next(barIt), end);
+        bar->children().push_back(key);
+        bar->children().push_back(val);
+        key->setParent(bar);
+        val->setParent(bar);
+        return bar;
+    }
+
     std::list<ExprNode*> tokens;
     tokens.insert(tokens.begin(), begin, end);
-    gErrorManager.log("Unknown type: '{" + toString(tokens) + "}'", ErrorManager::ERROR);
+    gErrorManager.log("Unknown type: '{" + toString(tokens) + " }'", ErrorManager::ERROR);
     return nullptr;
 }
 

--- a/lib/expr/parser.cpp
+++ b/lib/expr/parser.cpp
@@ -237,7 +237,8 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
         OpNode* op = (OpNode*)node;
         if (op->name() == "+" || op->name() == "-" || op->name() == "**" || op->name() == "*" ||
             op->name() == "/" || op->name() == "%" || op->name() == "mod" || op->name() == "^" ||
-            op->name() == "<" || op->name() == ">" || op->name() == "<=" || op->name() == ">=" || op->name() == "="||
+            op->name() == "<" || op->name() == ">" || op->name() == "<=" || op->name() == ">=" ||
+            op->name() == "="  || op->name() == "!=" ||
             op->name() == "or" || op->name() == "xor" || op->name() == "and")
         {         
             if (split == begin || split == rbegin) // arity mismatch

--- a/lib/expr/parser.cpp
+++ b/lib/expr/parser.cpp
@@ -334,9 +334,12 @@ std::list<ExprNode*> tokenizeStr(const std::string& expr)
             std::string name = expr.substr(itr, i - itr);
             ExprNode* node;
 
-            if (isOperator(name))       node = new OpNode(name);     // special case
-            else if (isFunction(name))  node = new FuncNode(name);
-            else                        node = new VarNode(name);
+            if (isOperator(name))                   node = new OpNode(name); 
+            else if (isFunction(name))              node = new FuncNode(name);
+            else if (isConstant(name))              node = new ConstNode(name);
+            else if (name == "true")                node = new BoolNode(true);
+            else if (name == "false")               node = new BoolNode(false);
+            else                                    node = new VarNode(name);
             tokens.push_back(node);
             itr = i;
         }

--- a/lib/expr/parser.cpp
+++ b/lib/expr/parser.cpp
@@ -238,7 +238,7 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
         if (op->name() == "+" || op->name() == "-" || op->name() == "**" || op->name() == "*" ||
             op->name() == "/" || op->name() == "%" || op->name() == "mod" || op->name() == "^" ||
             op->name() == "<" || op->name() == ">" || op->name() == "<=" || op->name() == ">=" || op->name() == "="||
-            op->name() == "or" || op->name() == "and") 
+            op->name() == "or" || op->name() == "xor" || op->name() == "and")
         {         
             if (split == begin || split == rbegin) // arity mismatch
             {
@@ -254,7 +254,7 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
             node->children().push_back(lhs);
             node->children().push_back(rhs);  
         }
-        else if (op->name() == "-*")
+        else if (op->name() == "-*" || op->name() == "not")
         {
             if (split == rbegin) // arity mismatch
             {

--- a/lib/expr/parser.cpp
+++ b/lib/expr/parser.cpp
@@ -95,23 +95,24 @@ ExprNode* parseString(const std::string& expr)
 // Parse Tokens
 //
 
-bool bracketedExpr(std::list<ExprNode*>::const_iterator begin, std::list<ExprNode*>::const_iterator end)
+bool bracketedExpr(std::list<ExprNode*>::iterator begin, std::list<ExprNode*>::iterator end)
 {
-    if (!(*begin)->isSyntax() || !(*end)->isSyntax() ||
-        !(((SyntaxNode*)*begin)->name() == "(" || ((SyntaxNode*)*begin)->name() == "[" || ((SyntaxNode*)*begin)->name() == "{") ||
-        !(((SyntaxNode*)*end)->name() == ")" || ((SyntaxNode*)*end)->name() == "]" || ((SyntaxNode*)*end)->name() == "}"))
+    ExprNode* first = *begin;
+    ExprNode* last = *std::prev(end);
+    if ((!first->isSyntax() || !isOpeningBracket(((SyntaxNode*)first)->name())) || 
+        (!last->isSyntax() || !isClosingBracket(((SyntaxNode*)last)->name())))
         return false;
 
     size_t bracketLevel = 0;
-    for (auto it = begin; it != std::next(end); ++it)
+    for (auto it = begin; it != end; ++it)
     {
-        if ((*it)->isSyntax() && (((SyntaxNode*)*it)->name() == "(" || ((SyntaxNode*)*it)->name() == "[" || ((SyntaxNode*)*it)->name() == "{"))
+        if ((*it)->isSyntax() && isOpeningBracket(((SyntaxNode*)*it)->name()))
         {
             ++bracketLevel;
         }
-        else if ((*it)->isSyntax() && (((SyntaxNode*)*it)->name() == ")" || ((SyntaxNode*)*it)->name() == "]" || ((SyntaxNode*)*it)->name() == "}"))
+        else if ((*it)->isSyntax() && isClosingBracket(((SyntaxNode*)*it)->name()))
         {
-            if (bracketLevel == 1 && it != end)  
+            if (bracketLevel == 1 && *it != last)
                 return false;
             --bracketLevel;
         } 
@@ -120,10 +121,10 @@ bool bracketedExpr(std::list<ExprNode*>::const_iterator begin, std::list<ExprNod
     return true;
 }
 
-ExprNode* captureDataType(std::list<ExprNode*>::const_iterator begin, std::list<ExprNode*>::const_iterator end)
+ExprNode* captureDataType(std::list<ExprNode*>::iterator begin, std::list<ExprNode*>::iterator end)
 {
     std::list<ExprNode*> tokens;
-    tokens.insert(tokens.begin(), begin, std::next(end));
+    tokens.insert(tokens.begin(), begin, end);
     gErrorManager.log("Unknown type: '{" + toString(tokens) + "}'", ErrorManager::ERROR);
     return nullptr;
 }
@@ -132,30 +133,32 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
 {
     if (bracketedExpr(begin, end))
     {
-        if (((SyntaxNode*)*begin)->name() == "{" && ((SyntaxNode*)*end)->name() == "}")   // '{ ... } implies a specific data type is contained within
+        ExprNode* first = *begin;
+        ExprNode* last = *std::prev(end);
+
+        if (((SyntaxNode*)first)->name() == "{" && ((SyntaxNode*)last)->name() == "}")   // '{ ... } implies a specific data type is contained within
             return captureDataType(std::next(begin), std::prev(end));
         
-        if (std::distance(begin, end) &&
-            (*std::next(begin))->isNumber() && (*std::prev(end))->isNumber() &&
+        if (std::distance(begin, end) == 5 &&
+            (*std::next(begin))->isNumber() && (*std::prev(end, 2))->isNumber() &&
             (*std::next(begin, 2))->isSyntax() && ((SyntaxNode*)*std::next(begin, 2))->name() == ",")
         {
-            Range range = { (*std::next(begin))->toString(), (*std::prev(end))->toString(), (((SyntaxNode*)*begin)->name() == "["), (((SyntaxNode*)*end)->name() == "]") };
+            Range range = { (*std::next(begin))->toString(), (*std::prev(end, 2))->toString(), (((SyntaxNode*)first)->name() == "["), (((SyntaxNode*)last)->name() == "]") };
             return new RangeNode(range);
         }
         
         return parseTokensR(std::next(begin),std::prev(end));
     }
 
-    auto split = end; // loop through tokens from end to beginning
-    auto rend = std::prev(begin);
+    auto split = std::prev(end); // loop through tokens from end to beginning
     size_t bracketLevel = 0;
-    for (auto it = end; it != rend; --it)
+    for (auto it = std::prev(end); it != std::prev(begin); --it)
     {
-        if ((*it)->isSyntax() && (((SyntaxNode*)*it)->name() == ")" || ((SyntaxNode*)*it)->name() == "]" || ((SyntaxNode*)*it)->name() == "}"))
+        if ((*it)->isSyntax() && isClosingBracket(((SyntaxNode*)*it)->name()))
         {
             ++bracketLevel;
         }
-        else if ((*it)->isSyntax() && (((SyntaxNode*)*it)->name() == "(" || ((SyntaxNode*)*it)->name() == "[" || ((SyntaxNode*)*it)->name() == "{"))
+        else if ((*it)->isSyntax() && isOpeningBracket(((SyntaxNode*)*it)->name()))
         {
             --bracketLevel;
         }
@@ -176,11 +179,11 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
 
     ExprNode* node = *split;
     auto next = std::next(split);
-    auto prev = std::prev(split);
+    auto rbegin = std::prev(end);
     if (node->type() == ExprNode::FUNCTION)
     {
         FuncNode* func = (FuncNode*)node;
-        if (split == end) // TODO: arity mismatch
+        if (split == rbegin) // TODO: arity mismatch
         {
             gErrorManager.log("Expected \"<func> (<args>...)\" for: " + func->name(), ErrorManager::ERROR);
             return nullptr;
@@ -206,7 +209,7 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
                     ++it2; // split arg vector
                 }
 
-                ExprNode* arg = parseTokensR(std::next(it), std::prev(it2));
+                ExprNode* arg = parseTokensR(std::next(it), (it2));
                 arg->setParent(node);
                 node->children().push_back(arg);
                 it = it2; 
@@ -221,13 +224,13 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
             op->name() == "<" || op->name() == ">" || op->name() == "<=" || op->name() == ">=" || op->name() == "="||
             op->name() == "or" || op->name() == "and") 
         {         
-            if (split == begin || split == end) // arity mismatch
+            if (split == begin || split == rbegin) // arity mismatch
             {
                 gErrorManager.log("Expected \"<lhs> " + op->name() + " <rhs>\"", ErrorManager::ERROR);
                 return nullptr;
             }
 
-            ExprNode* lhs = parseTokensR(begin, prev);
+            ExprNode* lhs = parseTokensR(begin, split);
             ExprNode* rhs = parseTokensR(next, end);
 
             lhs->setParent(node);
@@ -237,7 +240,7 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
         }
         else if (op->name() == "-*")
         {
-            if (split == end) // arity mismatch
+            if (split == rbegin) // arity mismatch
             {
                 gErrorManager.log("Expected \"" + op->name() + " <arg>\"", ErrorManager::ERROR);
                 return nullptr;
@@ -255,7 +258,7 @@ ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*
                 return nullptr;
             }
 
-            ExprNode* arg = parseTokensR(begin, prev);
+            ExprNode* arg = parseTokensR(begin, split);
             arg->setParent(node);
             node->children().push_back(arg);
         }
@@ -269,7 +272,7 @@ ExprNode* parseTokens(std::list<ExprNode*>& tokens)
     if (gErrorManager.hasError()) // Don't try to parse if there's an error =
         return nullptr;
 
-    ExprNode* expr = parseTokensR(tokens.begin(), std::prev(tokens.end()));
+    ExprNode* expr = parseTokensR(tokens.begin(), tokens.end());
     if (expr != nullptr) consumeFrom(expr, tokens);
     for (auto e : tokens) delete e;
     tokens.clear();
@@ -320,11 +323,6 @@ std::list<ExprNode*> tokenizeStr(const std::string& expr)
             tokens.push_back(node);
             itr = i;
         }
-        else if (expr[itr] == ',') // TODO: syntax nodes other than brackets
-        {
-            tokens.push_back(new SyntaxNode(std::string(1, expr[itr])));
-            ++itr;
-        }
         else if (isBracket(expr[itr]))
         {
             if (expr[itr] == '(' || expr[itr] == '{' || expr[itr] == '[')
@@ -354,6 +352,11 @@ std::list<ExprNode*> tokenizeStr(const std::string& expr)
             
             ExprNode* bracket = new SyntaxNode(std::string(1, expr[itr]));
             tokens.push_back(bracket);
+            ++itr;
+        }
+        else if (isSyntax(expr[itr])) // TODO: syntax nodes other than brackets
+        {
+            tokens.push_back(new SyntaxNode(std::string(1, expr[itr])));
             ++itr;
         }
         else if (isOperator(expr[itr]))

--- a/lib/expr/parser.h
+++ b/lib/expr/parser.h
@@ -16,6 +16,9 @@ void expandTokens(std::list<ExprNode*>& tokens);
 // inspect the tokens.
 ExprNode* parseString(const std::string& expr);
 
+// Recursively parses and builds an expression tree.
+ExprNode* parseTokensR(std::list<ExprNode*>::iterator begin, std::list<ExprNode*>::iterator end);
+
 // Builds an expression tree from a vector of tokens. The list will be consumed.
 ExprNode* parseTokens(std::list<ExprNode*>& tokens);
 

--- a/lib/expr/polynomial.cpp
+++ b/lib/expr/polynomial.cpp
@@ -251,7 +251,10 @@ ExprNode* reorderPolynomial(ExprNode* expr, bool down)
 #endif
 
     for (auto e : expr->children())
-        e->children().sort(monomialBasisGt);
+    {
+        if (expr->isOperator() && (((OpNode*)expr)->name() == "*" || ((OpNode*)expr)->name() == "**"))
+            e->children().sort(monomialBasisGt);
+    }
 
     if (!expr->isOperator() || (((OpNode*)expr)->name() != "+" && ((OpNode*)expr)->name() != "-")) // single term
         return expr;

--- a/lib/mathsolver.h
+++ b/lib/mathsolver.h
@@ -2,11 +2,8 @@
 #define _MATHSOLVER_MATHSOLVER_H_
 
 #include "common/base.h"
-#include "eval/arithmetic.h"
 #include "eval/evaluator.h"
-#include "expr/arithmetic.h"
 #include "expr/expr.h"
-#include "expr/node.h"
 #include "expr/parser.h"
 #include "expr/polynomial.h"
 #include "math/float-math.h"

--- a/lib/mathsolver.h
+++ b/lib/mathsolver.h
@@ -2,12 +2,19 @@
 #define _MATHSOLVER_MATHSOLVER_H_
 
 #include "common/base.h"
+
+#include "eval/arithmetic.h"
+#include "eval/arithrr.h"
 #include "eval/evaluator.h"
+
+#include "expr/arithmetic.h"
 #include "expr/expr.h"
 #include "expr/parser.h"
 #include "expr/polynomial.h"
+
 #include "math/float-math.h"
 #include "math/integer-math.h"
+
 #include "types/float.h"
 #include "types/integer.h"
 

--- a/lib/mathsolver.h
+++ b/lib/mathsolver.h
@@ -6,6 +6,8 @@
 #include "eval/arithmetic.h"
 #include "eval/arithrr.h"
 #include "eval/evaluator.h"
+#include "eval/inequality.h"
+#include "eval/inequalityrr.h"
 
 #include "expr/arithmetic.h"
 #include "expr/expr.h"

--- a/lib/test/test-common.cpp
+++ b/lib/test/test-common.cpp
@@ -7,6 +7,7 @@ std::string TestModule::result() const
 {
     std::string results;
     std::string totalStr = std::to_string(mResults.size());
+    std::string other = gErrorManager.toString();
     size_t i = 1;
     for (const std::string& s : mResults)
     {
@@ -15,7 +16,8 @@ std::string TestModule::result() const
         ++i;
     }
 
-    return std::to_string(mPassed) + "/" + totalStr + " \"" + mName + "\"" + results;
+    if (!other.empty()) other = "\n" + other;
+    return std::to_string(mPassed) + "/" + totalStr + " \"" + mName + "\"" + results + other;
 }
 
 void TestModule::runTest(const std::string& test, const std::string& expected)

--- a/lib/test/test-common.cpp
+++ b/lib/test/test-common.cpp
@@ -17,6 +17,7 @@ std::string TestModule::result() const
     }
 
     if (!other.empty()) other = "\n" + other;
+    gErrorManager.clear();
     return std::to_string(mPassed) + "/" + totalStr + " \"" + mName + "\"" + results + other;
 }
 

--- a/lib/test/test-common.cpp
+++ b/lib/test/test-common.cpp
@@ -7,7 +7,6 @@ std::string TestModule::result() const
 {
     std::string results;
     std::string totalStr = std::to_string(mResults.size());
-    std::string other = gErrorManager.toString();
     size_t i = 1;
     for (const std::string& s : mResults)
     {
@@ -16,25 +15,20 @@ std::string TestModule::result() const
         ++i;
     }
 
-    if (!other.empty()) other = "\n" + other;
-    gErrorManager.clear();
-    return std::to_string(mPassed) + "/" + totalStr + " \"" + mName + "\"" + results + other;
+    return std::to_string(mPassed) + "/" + totalStr + " \"" + mName + "\"" + results;
 }
 
 void TestModule::runTest(const std::string& test, const std::string& expected)
 {
-    std::string result;
-    if (test == expected)
+    std::string result = std::string((test == expected) ? "PASS" : "FAIL") + "\tExpected: " + expected + "\tActual: " + test;
+    if (test == expected)    ++mPassed;
+    if (gErrorManager.hasAny())
     {
-        result += "PASS";
-        ++mPassed;
-    }
-    else
-    {
-        result += "FAIL";
+        result += ("\n" + gErrorManager.toString());
+        gErrorManager.clear();
     }
 
-    mResults.push_back(result + "\tExpected: " + expected + "\tActual: " + test);
+    mResults.push_back(result);
 }
 
 void TestModule::reset(const std::string& name)

--- a/lib/types/float.cpp
+++ b/lib/types/float.cpp
@@ -5,6 +5,9 @@
 namespace MathSolver
 {
 
+const Float POS_INFINITY = Float("+inf");
+const Float NEG_INFINITY = Float("-inf");
+
 Float::Float()
 {
     mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
@@ -15,6 +18,13 @@ Float::Float(const Float& other)
 {
     mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
     mRoundDir = mpfr_set(mData, other.mData, MATHSOLVER_FLOAT_DEFAULT_RND_MODE);
+}
+
+Float::Float(Float&& other)
+{
+    *mData = *other.mData;
+    mRoundDir = other.mRoundDir;
+    other.mData->_mpfr_d = nullptr;
 }
 
 Float::Float(const char* data)
@@ -31,26 +41,42 @@ Float::Float(const std::string& data)
 
 Float::~Float()
 {
-    mpfr_clear(mData);
+    if (mData->_mpfr_d != nullptr)
+        mpfr_clear(mData);
 }
 
 Float& Float::operator=(const Float& other)
 {
-    if (mData->_mpfr_d == NULL) mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
+    if (mData->_mpfr_d != nullptr) 
+        mpfr_clear(mData);
+    
+    mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
     mRoundDir = mpfr_set(mData, other.mData, MATHSOLVER_FLOAT_DEFAULT_RND_MODE);
+    return *this;
+}
+
+Float& Float::operator=(Float&& other)
+{
+    if (mData->_mpfr_d != nullptr)
+        mpfr_clear(mData);
+    
+    *mData = *other.mData;
+    mRoundDir = other.mRoundDir;
+    other.mData->_mpfr_d = nullptr;
+
     return *this;
 }
 
 Float& Float::operator=(const char* data)
 {
-    if (mData->_mpfr_d == NULL) mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
+    if (mData->_mpfr_d == nullptr) mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
     fromString(data);
     return *this;
 }
 
 Float& Float::operator=(const std::string& data)
 {
-    if (mData->_mpfr_d == NULL) mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
+    if (mData->_mpfr_d == nullptr) mpfr_init2(mData, MATHSOLVER_FLOAT_DEFAULT_PREC);
     fromString(data.c_str()); 
     return *this;
 }

--- a/lib/types/float.h
+++ b/lib/types/float.h
@@ -23,9 +23,11 @@ public:
     Float(const char* data);            // Constructor from C string
     Float(const std::string& data);     // Constructor from std::string
     Float(const Float& other);          // Copy constructor
+    Float(Float&& other);               // Move constructor
     ~Float();                           // Destructor
 
     Float& operator=(const Float& other);       // Copy assignment
+    Float& operator=(Float&& other);            // Move assignment
     Float& operator=(const char* data);         // Assignment from c string
     Float& operator=(const std::string& data);  // Assignment from std::string
 
@@ -84,6 +86,10 @@ private:
     mpfr_t  mData;
     int     mRoundDir;
 };
+
+extern const Float POS_INFINITY;
+extern const Float NEG_INFINITY;
+
 
 }
 

--- a/lib/types/range.h
+++ b/lib/types/range.h
@@ -60,7 +60,7 @@ public:
     Range(const Float& lower, const Float& upper, bool lclosed, bool uclosed); 
 
     // Single interval (interval_t)
-    inline Range(const interval_t ival) { mIntervals.push_back(ival); }
+    inline Range(const interval_t& ival) { mIntervals.push_back(ival); }
 
     // Multiple intervals (interval_t)
     Range(const std::initializer_list<interval_t>& ivals);
@@ -88,6 +88,10 @@ public:
 
     // Returns true if the value is contained within this Range.
     bool contains(const Float& val) const;
+
+    // Returns a reference to the underlying.
+    inline std::list<interval_t>& data() { return mIntervals; }
+    inline const std::list<interval_t>& data() const { return mIntervals; }
 
     // Returns the disjunction (union) of this Range and another.
     Range disjoin(const Range& other) const;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -13,15 +13,15 @@ int parseLine(const std::string& line)
 
     if (gErrorManager.hasError())
     {   
-        std::cout << gErrorManager.toString();
+        std::cout << gErrorManager.toString() << std::endl;
         return 1;
     }
 
     flattenExpr(eval);
-    eval = rrAndEvalExpr(eval);
+    eval = evaluateExpr(eval);
     if (gErrorManager.hasError())
     {   
-        std::cout << gErrorManager.toString();
+        std::cout << gErrorManager.toString() << std::endl;
         return 1;
     }
     

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -12,18 +12,12 @@ int parseLine(const std::string& line)
     ExprNode* eval = parseString(line);
 
     if (gErrorManager.hasError())
-    {   
         std::cout << gErrorManager.toString() << std::endl;
-        return 1;
-    }
 
     flattenExpr(eval);
     eval = evaluateExpr(eval);
     if (gErrorManager.hasError())
-    {   
         std::cout << gErrorManager.toString() << std::endl;
-        return 1;
-    }
     
     std::cout << toInfixString(eval) << std::endl;
     freeExpression(eval);

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -18,7 +18,7 @@ int parseLine(const std::string& line)
     }
 
     flattenExpr(eval);
-    eval = evaluateExpr(eval);
+    eval = rrAndEvalExpr(eval);
     if (gErrorManager.hasError())
     {   
         std::cout << gErrorManager.toString();

--- a/tests/test-arithmetic.cpp
+++ b/tests/test-arithmetic.cpp
@@ -12,7 +12,7 @@ bool evalExpr(TestModule& tester, const std::string exprs[], size_t count)
 	{
 		ExprNode* expr = parseString(exprs[2 * i]);
 		flattenExpr(expr);
-		expr = evaluateExpr(expr);
+		expr = rrAndEvalExpr(expr);
 		tester.runTest(toInfixString(expr), exprs[2 * i + 1]);
 		freeExpression(expr);
 	}
@@ -76,7 +76,7 @@ int main()
 			"100-1000",			"-900",
 			"500-600-200",		"-300",
 			"5z-2z-9-6",		"3z-15",
-			"2x-y-3x",			"-x-y"
+			"2x-y-3x",			"-(x+y)"
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);

--- a/tests/test-arithmetic.cpp
+++ b/tests/test-arithmetic.cpp
@@ -12,7 +12,7 @@ bool evalExpr(TestModule& tester, const std::string exprs[], size_t count)
 	{
 		ExprNode* expr = parseString(exprs[2 * i]);
 		flattenExpr(expr);
-		expr = rrAndEvalExpr(expr);
+		expr = evaluateExpr(expr);
 		tester.runTest(toInfixString(expr), exprs[2 * i + 1]);
 		freeExpression(expr);
 	}
@@ -172,13 +172,17 @@ int main()
 
 	tests.reset("*,^ mixed");
 	{
-		const size_t COUNT = 4;
+		const size_t COUNT = 8;
 		const std::string exprs[COUNT * 2] = 
 		{ 
 			"x*x",		"x^2",
 			"x*x^2",	"x^3",
 			"x^2*x",	"x^3",
-			"x^2*x^2",	"x^4"
+			"x^2*x^2",	"x^4",
+			"x^5/x",	"x^4",
+			"x/x^5",	"1/x^4",
+			"x^5/x^3",	"x^2",
+			"x^3/x^5", 	"x^-2"
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);

--- a/tests/test-arithmetic.cpp
+++ b/tests/test-arithmetic.cpp
@@ -76,7 +76,7 @@ int main()
 			"100-1000",			"-900",
 			"500-600-200",		"-300",
 			"5z-2z-9-6",		"3z-15",
-			"2x-y-3x",			"-(x+y)"
+			"2x-y-3x",			"-x-y"
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);
@@ -126,7 +126,7 @@ int main()
 		const size_t COUNT = 4;
 		const std::string exprs[COUNT * 2] = 
 		{ 
-			"a+b/c*d",			"bd/c+a",
+			"a+b/c*d",			"a+bd/c",
 			"-a+b*c+d", 		"b*c-a+d",
 			"(3a+5a)/5a",		"8/5",
 			"2a/(15*a*b)",		"2/15b"

--- a/tests/test-boolean.cpp
+++ b/tests/test-boolean.cpp
@@ -1,0 +1,84 @@
+#include <iostream>
+#include <list>
+#include <string>
+#include "../lib/mathsolver.h"
+#include "../lib/test/test-common.h"
+
+using namespace MathSolver;
+
+bool evalExpr(TestModule& tester, const std::string exprs[], size_t count)
+{
+	for (size_t i = 0; i < count; ++i)
+	{
+		ExprNode* expr = parseString(exprs[2 * i]);
+		flattenExpr(expr);
+		expr = evaluateExpr(expr);
+		tester.runTest(toInfixString(expr), exprs[2 * i + 1]);
+		freeExpression(expr);
+	}
+
+	std::cout << tester.result() << std::endl;
+	return tester.status();
+}
+
+int main()
+{
+	bool status = true;
+	bool verbose = false;
+
+	{
+        TestModule tests("not", verbose);
+		const size_t COUNT = 2;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"not false",		"true",
+			"not true",			"false"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+	{
+        TestModule tests("or", verbose);
+		const size_t COUNT = 4;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"false or false",			"false",
+			"true or false",			"true",
+			"false or true",			"true",
+			"true or true",				"true"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+	{
+        TestModule tests("xor", verbose);
+		const size_t COUNT = 4;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"false xor false",			"false",
+			"true xor false",			"true",
+			"false xor true",			"true",
+			"true xor true",			"false"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+	{
+        TestModule tests("and", verbose);
+		const size_t COUNT = 4;
+		const std::string exprs[COUNT * 2] = 
+		{ 	
+			"false and false",			"false",
+			"true and false",			"false",
+			"false and true",			"false",
+			"true and true",			"true"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+    return (int)(!status);
+}

--- a/tests/test-inequality.cpp
+++ b/tests/test-inequality.cpp
@@ -1,0 +1,128 @@
+#include <iostream>
+#include <list>
+#include <string>
+#include "../lib/mathsolver.h"
+#include "../lib/test/test-common.h"
+
+using namespace MathSolver;
+
+bool evalExpr(TestModule& tester, const std::string exprs[], size_t count)
+{
+	for (size_t i = 0; i < count; ++i)
+	{
+		ExprNode* expr = parseString(exprs[2 * i]);
+		flattenExpr(expr);
+		expr = evaluateExpr(expr);
+		tester.runTest(toInfixString(expr), exprs[2 * i + 1]);
+		freeExpression(expr);
+	}
+
+	std::cout << tester.result() << std::endl;
+	return tester.status();
+}
+
+int main()
+{
+	bool status = true;
+	bool verbose = false;
+
+	{
+        TestModule tests(">", verbose);
+		const size_t COUNT = 8;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"2>1",      "true",
+            "1>2",      "false",
+            "1>1",      "false",
+            "x>2",      "x>2",
+            "3>2>1",    "true",
+            "3>1>2",    "false",
+            "3>x>2",    "2<x<3",
+            "2>x>3",    "false"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+    {
+        TestModule tests("<", verbose);
+		const size_t COUNT = 8;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"1<2",      "true",
+            "2<1",      "false",
+            "1<1",      "false",
+            "x<2",      "x<2",
+            "1<2<3",    "true",
+            "1<3<2",    "false",
+            "2<x<3",    "2<x<3",
+            "3<x<2",    "false"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+    {
+        TestModule tests(">=", verbose);
+		const size_t COUNT = 8;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"2>=1",      "true",
+            "1>=2",      "false",
+            "1>=1",      "true",
+            "x>=2",      "x>=2",
+            "3>=2>=1",   "true",
+            "3>=1>=2",   "false",
+            "3>=x>=2",   "2<=x<=3",
+            "2>=x>=3",   "false"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+    {
+        TestModule tests("<=", verbose);
+		const size_t COUNT = 8;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"1<=2",      "true",
+            "2<=1",      "false",
+            "1<=1",      "true",
+            "x<=2",      "x<=2",
+            "1<=2<=3",   "true",
+            "1<=3<=2",   "false",
+            "2<=x<=3",   "2<=x<=3",
+            "3<=x<=2",   "false"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+    {
+        TestModule tests("!=", verbose);
+		const size_t COUNT = 4;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"1!=2",     "true",
+            "1!=1",     "false",
+            "x!=x",     "false",
+            "x!=y",     "x!=y"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+	{
+		TestModule tests("Mixed intervals", verbose);
+		const size_t COUNT = 2;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"1<=x<2",		"1<=x<2",
+			"1<=x<y<=2",	"1<=x and x<y and y<=2"
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+    return (int)(!status);
+}


### PR DESCRIPTION
This PR adds evaluations rules for inequalities, boolean expressions, and ranges. In addition, a rewrite stage has been added for arithmetic and inequality expressions. Rewrites are applied before simplification in order to catch edge cases and make evaluation easier.