### PR TITLE
Added match expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ test-floatmath: build/test-floatmath
 test-range: build/test-range
 	$(TEST_DIR)/test.sh build/test-range
 
+test-matcher: build/test-matcher
+	$(TEST_DIR)/test.sh build/test-matcher
+
 test-parser: build/test-parser
 	$(TEST_DIR)/test.sh build/test-parser
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: build-tests main;
 main: $(OBJS)
 	$(CXX) $(CXXFLAGS) $(OBJS) $(SRC_DIR)/$(ENTRY) $(LDFLAGS) -o $(EXE)
 
-tests: $(OBJS) $(TEST_EXES)
+tests: $(TEST_EXES)
 	$(TEST_DIR)/test.sh $(TEST_EXES)
 
 memcheck: $(OBJS) $(TEST_EXES)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TESTS 		:= $(shell find $(TEST_DIR) -name *.cpp)
 TEST_EXES 	:= $(TESTS:$(TEST_DIR)/%.cpp=$(BUILD_DIR)/%)
 
 DEPFLAGS 	:= -MMD -MP
-CXXFLAGS 	:= -g -O0 -Wall -std=c++17
+CXXFLAGS 	:= -g -Wall -std=c++17
 LDFLAGS 	:= -lmpfr -lgmp
 
 .PRECIOUS: $(BUILD_DIR)/. $(BUILD_DIR)%/.

--- a/lib/eval/arithmetic.cpp
+++ b/lib/eval/arithmetic.cpp
@@ -599,36 +599,6 @@ ExprNode* symbolicMul(ExprNode* op)
     // reorder monomial
     if (isMonomial(op))    op = reorderMonomial(op);
 
-    for (auto it = op->children().begin(); it != op->children().end() && std::next(it) != op->children().end(); ++it)
-    {
-        auto it2 = std::next(it);
-        while (it2 != op->children().end())
-        {
-            if (eqvExpr(peekPowBase(*it), peekPowBase(*it2))) // (* (^ a n) ... (^ a m)) ==> (* (^ a (+ n m)) ... )
-            {
-                ExprNode* pow = new OpNode("^", op);
-                ExprNode* add = new OpNode("+", pow);  
-
-                add->children().push_back(extractPowExp(*it));
-                add->children().push_back(extractPowExp(*it2));
-                add = evaluateArithmetic(add);
-
-                pow->children().push_back(extractPowBase(*it));
-                pow->children().push_back(add);
-                pow = evaluateArithmetic(pow);
-
-                freeExpression(*it);
-                freeExpression(*it2);
-                it2 = op->children().erase(it2);
-                it = replaceChild(op, pow, it);              
-            }  
-            else
-            {
-                ++it2;
-            } 
-        }
-    }
-
     UniqueExprTransformer etrans;
     etrans.add("(* ?a)", "?a");
     etrans.add("(* 0 ?a ...?)", "0");

--- a/lib/expr/expr.cpp
+++ b/lib/expr/expr.cpp
@@ -16,6 +16,15 @@ const std::string FLATTENABLE_OPS[FLATTENABLE_OP_COUNT] =
 
 ExprNode* copyOf(ExprNode* expr)
 {
+	ExprNode* cp = copyNodeNoTree(expr);
+
+	for (ExprNode* child : expr->children())
+		cp->children().push_back(copyOf(child));
+	return cp;
+}
+
+ExprNode* copyNodeNoTree(ExprNode* expr)
+{
 	ExprNode* cp;
 	if (expr->type() == ExprNode::SYNTAX) 			cp = new SyntaxNode(((SyntaxNode*)expr)->name(), expr->parent());
 	else if (expr->type() == ExprNode::OPERATOR) 	cp = new OpNode(((OpNode*)expr)->name(), expr->parent());
@@ -28,8 +37,6 @@ ExprNode* copyOf(ExprNode* expr)
 	else if (expr->type() == ExprNode::BOOLEAN)		cp = new BoolNode(((BoolNode*)expr)->value(), expr->parent());
 	else 		gErrorManager.log("Should not have executed here", ErrorManager::FATAL, __FILE__, __LINE__);
 
-	for (ExprNode* child : expr->children())
-		cp->children().push_back(copyOf(child));
 	return cp;
 }
 

--- a/lib/expr/expr.cpp
+++ b/lib/expr/expr.cpp
@@ -17,9 +17,13 @@ const std::string FLATTENABLE_OPS[FLATTENABLE_OP_COUNT] =
 ExprNode* copyOf(ExprNode* expr)
 {
 	ExprNode* cp = copyNode(expr);
-	
-	for (ExprNode* child : expr->children())
-		cp->children().push_back(copyOf(child));
+	for (auto child : expr->children())
+	{
+		ExprNode* t = copyOf(child);
+		cp->children().push_back(t);
+		t->setParent(cp);
+	}
+
 	return cp;
 }
 

--- a/lib/expr/expr.cpp
+++ b/lib/expr/expr.cpp
@@ -16,27 +16,10 @@ const std::string FLATTENABLE_OPS[FLATTENABLE_OP_COUNT] =
 
 ExprNode* copyOf(ExprNode* expr)
 {
-	ExprNode* cp = copyNodeNoTree(expr);
-
+	ExprNode* cp = copyNode(expr);
+	
 	for (ExprNode* child : expr->children())
 		cp->children().push_back(copyOf(child));
-	return cp;
-}
-
-ExprNode* copyNodeNoTree(ExprNode* expr)
-{
-	ExprNode* cp;
-	if (expr->type() == ExprNode::SYNTAX) 			cp = new SyntaxNode(((SyntaxNode*)expr)->name(), expr->parent());
-	else if (expr->type() == ExprNode::OPERATOR) 	cp = new OpNode(((OpNode*)expr)->name(), expr->parent());
-	else if (expr->type() == ExprNode::FUNCTION) 	cp = new FuncNode(((FuncNode*)expr)->name(), expr->parent());
-	else if (expr->type() == ExprNode::VARIABLE) 	cp = new VarNode(((VarNode*)expr)->name(), expr->parent());
-	else if (expr->type() == ExprNode::CONSTANT) 	cp = new ConstNode(((ConstNode*)expr)->name(), expr->parent());
-	else if (expr->type() == ExprNode::INTEGER) 	cp = new IntNode(((IntNode*)expr)->value(), expr->parent());
-	else if (expr->type() == ExprNode::FLOAT)		cp = new FloatNode(((FloatNode*)expr)->value(), expr->parent());
-	else if (expr->type() == ExprNode::RANGE)		cp = new RangeNode(((RangeNode*)expr)->value(), expr->parent());
-	else if (expr->type() == ExprNode::BOOLEAN)		cp = new BoolNode(((BoolNode*)expr)->value(), expr->parent());
-	else 		gErrorManager.log("Should not have executed here", ErrorManager::FATAL, __FILE__, __LINE__);
-
 	return cp;
 }
 

--- a/lib/expr/expr.h
+++ b/lib/expr/expr.h
@@ -2,7 +2,7 @@
 #define _MATHSOLVER_EXPRESSION_H_
 
 #include "../common/base.h"
-#include "../expr/node.h"
+#include "node.h"
 
 namespace MathSolver
 {

--- a/lib/expr/expr.h
+++ b/lib/expr/expr.h
@@ -35,6 +35,9 @@ inline bool containsType(ExprNode* expr, ExprNode::Type type) { return containsO
 // Returns a copy of the given expression tree.
 ExprNode* copyOf(ExprNode* expr);
 
+// Returns a copy of the given expression node with no tree information
+ExprNode* copyNodeNoTree(ExprNode* expr);
+
 // Returns true if the value of two nodes is the same.
 bool eqvExpr(ExprNode* a, ExprNode* b);
 

--- a/lib/expr/expr.h
+++ b/lib/expr/expr.h
@@ -48,6 +48,9 @@ void flattenExpr(ExprNode* expr);
 // Deletes an expression tree.
 void freeExpression(ExprNode* expr);
 
+// Returns the given expression unaltered. This is the default transform, corresponding to f(x) = x.
+inline ExprNode* identity(ExprNode* expr) { return expr; }
+
 // Returns true if the expression only contains numerical operands (Non-symbolic expression).
 inline bool isNumerical(ExprNode* expr)
 { 

--- a/lib/expr/expr.h
+++ b/lib/expr/expr.h
@@ -11,6 +11,8 @@ namespace MathSolver
 //  Expression operations
 //
 
+typedef ExprNode* Transform (ExprNode*);
+
 // Returns true if every node in the expression satisfies the given predicate.
 template <typename Pred>
 bool containsAll(ExprNode* expr, Pred pred)

--- a/lib/expr/expr.h
+++ b/lib/expr/expr.h
@@ -35,9 +35,6 @@ inline bool containsType(ExprNode* expr, ExprNode::Type type) { return containsO
 // Returns a copy of the given expression tree.
 ExprNode* copyOf(ExprNode* expr);
 
-// Returns a copy of the given expression node with no tree information
-ExprNode* copyNodeNoTree(ExprNode* expr);
-
 // Returns true if the value of two nodes is the same.
 bool eqvExpr(ExprNode* a, ExprNode* b);
 

--- a/lib/expr/matcher.cpp
+++ b/lib/expr/matcher.cpp
@@ -163,7 +163,10 @@ ExprNode* buildTree(const std::list<std::string> tokens, const std::map<std::str
     if (tokens.size() == 1)
     {
         if (matchDict.find(tokens.front()) != matchDict.end())
-            return copyNodeNoTree(matchDict.at(tokens.front()));
+        {
+            if (tokens.front().front() == '?')  return copyOf(matchDict.at(tokens.front()));
+            else                                return copyNode(matchDict.at(tokens.front()));
+        }
         
         std::list<ExprNode*> exprTokens = tokenizeStr(tokens.front());
         return exprTokens.front();
@@ -206,7 +209,7 @@ ExprNode* applyMatchTransform(const std::string& input, const std::string& outpu
 
 UniqueTransformMatcher::UniqueTransformMatcher()   // default constructor
 {
-    successful = false;
+    mSuccess = false;
 }
 
 void UniqueTransformMatcher::add(const std::string& input, const std::string& output)
@@ -227,18 +230,24 @@ void UniqueTransformMatcher::add(const std::string& input, const std::string& ou
     }
 }
 
+void UniqueTransformMatcher::clear()
+{
+    mTransforms.clear();
+    mSuccess = false;
+}
+
 ExprNode* UniqueTransformMatcher::transform(ExprNode* expr)
 {
     for (auto e : mTransforms)
     {
         if (matchExpr(e.first, expr))   // if match, return transform
         {
-            successful = true;
+            mSuccess = true;
             return applyMatchTransform(e.first, e.second, expr);
         }
     }
 
-    successful = false;
+    mSuccess = false;
     return expr; // else, return unaltered
 }
 

--- a/lib/expr/matcher.cpp
+++ b/lib/expr/matcher.cpp
@@ -92,10 +92,10 @@ MatchExpr::node MatchExpr::buildMatchTree(const std::vector<std::string>& tokens
     }
     else
     {
-        if (tokens.front() != "(" && tokens.front() != ")")
+        if (tokens.front() != "(" || tokens.back() != ")")
         {
             gErrorManager.log("Expected a subexpression inside parenthesis!", ErrorManager::FATAL);
-            return node();
+            return { "null", std::vector<node>(), nullptr, node::SINGLE, 0 };
         }
 
         node top;
@@ -125,7 +125,7 @@ MatchExpr::node MatchExpr::buildMatchTree(const std::vector<std::string>& tokens
                 if (i + 1 != end)
                 {
                     gErrorManager.log("Ellipses can only appear at the end of a subexpression", ErrorManager::FATAL);
-                    return node();
+                    return { "null", std::vector<node>(), nullptr, node::SINGLE, 0 };
                 }
 
                 top.children.back().depth += 1;
@@ -140,8 +140,17 @@ MatchExpr::node MatchExpr::buildMatchTree(const std::vector<std::string>& tokens
 
         auto pred = [](const node& lhs, const node& rhs) { return lhs.depth < rhs.depth; };
         auto it = std::min_element(top.children.begin(), top.children.end(), pred);
-        top.depth = it->depth + 1; // min(children) + 1
-        return top;
+        if (it != top.children.end())
+        {
+            top.depth = it->depth + 1; // min(children) + 1
+            return top;
+        }
+        else
+        {
+            gErrorManager.log("Malformed match expression", ErrorManager::FATAL);
+            return { "null", std::vector<node>(), nullptr, node::SINGLE, 0 };
+        }
+        
     }
 }
 
@@ -156,7 +165,8 @@ ExprNode* MatchExpr::createLeaf(const node& match, const MatchDict& dict) const
             return copyNode(inDict);
     }
 
-    return parseString(match.name);
+    std::list<ExprNode*> tokens = tokenizeStr(match.name);
+    return tokens.front();
 }
 
 ExprNode* MatchExpr::createSubexpr(const node& match, const MatchDict& dict) const
@@ -380,6 +390,7 @@ bool MatchExpr::matchSubexpr(const node& match, ExprNode* expr, MatchDict& dict)
                 {
                     before->children().insert(before->children().end(),
                                               possible.begin(), possible.end());
+                    before->children().push_back(*it);
                     possible.clear();
                     idx = 0;
                 }
@@ -424,7 +435,7 @@ bool MatchExpr::matchSubexpr(const node& match, ExprNode* expr, MatchDict& dict)
     return true;
 }
 
-std::vector<std::string> tokenizeMatchString(const std::string& match)
+std::vector<std::string> MatchExpr::tokenizeMatchString(const std::string& match)
 {
     std::vector<std::string> tokens;
     size_t len = match.length();
@@ -463,486 +474,6 @@ std::string MatchExpr::toString(const MatchExpr::node& tree) const
     }
 
     return accum + ")";
-}
-
-bool isMatchString(const std::string& match)
-{
-    std::vector<std::string> tokens = tokenizeMatchString(match);
-    std::map<int, int> subexprCount;
-    std::map<int, bool> ellipseUsed;
-    int parenCount = 0;
-
-    for (size_t i = 0; i < tokens.size(); ++i)
-    {
-        if (tokens[i] == "(")
-        {
-            // increment subexpr count of this subexpr layer
-            if (subexprCount.find(parenCount) != subexprCount.end())    ++subexprCount[parenCount];
-            else                                                        subexprCount[parenCount] = 1;
-            
-            // set the next layer to 0
-            ++parenCount;
-            subexprCount[parenCount] = 0;
-            ellipseUsed[parenCount] = false;
-        }
-        else if (tokens[i] == ")")
-        {
-            if (subexprCount[parenCount] == 0)      return false;
-            subexprCount.erase(parenCount);
-            ellipseUsed.erase(parenCount);
-            --parenCount;
-        }
-        else if (tokens[i] == "...")
-        {
-            if (ellipseUsed[parenCount])       return false;
-            ellipseUsed[parenCount] = true;
-        }
-        else if (tokens[i] == "...?")
-        {
-            if (tokens[i + 1] != ")")          return false; // this token may only appear in the tail
-            if (ellipseUsed[parenCount])       return false;
-            ellipseUsed[parenCount] = true;
-        }
-        else
-        {
-            ++subexprCount[parenCount]; // assume this subexpr count has been set to 0
-        }     
-    }
-
-    if (parenCount != 0)    return false; // unmatched parenthesis
-    return true;
-}
-
-std::vector<std::string> extractMatchSubexpr(const std::vector<std::string>& match,
-                                             std::vector<std::string>::const_iterator& it)
-{
-    std::vector<std::string> subexpr;
-    if (*it == "(")
-    {
-        auto it2 = std::next(it);
-        int parenCount = 1;
-        for (; it2 != match.end() && parenCount > 0; ++it2)
-        {
-            if (*it2 == "(")        ++parenCount;
-            else if (*it2 == ")")   --parenCount;
-        }
-
-        subexpr.insert(subexpr.begin(), it, it2);
-    }
-    else
-    {
-        subexpr.push_back(*it);
-    }
-
-    return subexpr;
-}
-
-bool matchExprToken(const std::string& token, ExprNode* expr,
-                    std::map<std::string, ExprNode*>& matchDict,
-                    std::map<std::vector<std::string>, ExprNode*>& unknownDict)
-{
-    if (token.front() == '?')   
-    {
-        if (matchDict.find(token) == matchDict.end())
-        {
-            matchDict[token] = expr;
-            auto it = unknownDict.begin(); 
-            while (it != unknownDict.end())
-            {
-                const std::string& key = it->first[0];
-                const std::string& rest = it->first[1];
-                if (token == key)
-                {
-                    ExprNode* ell = new SyntaxNode("...?");
-                    ExprNode* before = new SyntaxNode("before", ell);
-                    ExprNode* after = new SyntaxNode("after", ell);
-
-                    ell->children().push_back(before);
-                    ell->children().push_back(after);
-
-                    bool found = false;
-                    for (auto n : it->second->children())
-                    {
-                        if (eqvExpr(n, expr))   found = true;
-                        else if (found)         after->children().push_back(n);
-                        else                    before->children().push_back(n);
-                    }
-
-                    matchDict[rest] = ell;
-                    delete it->second;
-                    it = unknownDict.erase(it);
-                }
-                else
-                {
-                    ++it;
-                }    
-            }
-
-            return true;
-        }
-
-        return eqvExpr(matchDict.at(token), expr);   
-    }
-
-    if (matchDict.find(token) == matchDict.end())
-        matchDict[token] = expr;
-    return token == expr->toString();
-}
-
-bool matchExprHelper(const std::vector<std::string> tokens, ExprNode* expr,
-                     std::map<std::string, ExprNode*>& matchDict,
-                     std::map<std::vector<std::string>, ExprNode*>& unknownDict)
-{
-    if (tokens.size() == 1)
-        return matchExprToken(tokens.front(), expr, matchDict, unknownDict);
-
-    std::vector<std::vector<std::string>> sexprs;
-    auto it = std::next(tokens.begin());
-    auto end = std::prev(tokens.end());
-    
-    while (it != end)
-    {
-        std::vector<std::string> s = extractMatchSubexpr(tokens, it);
-        it = std::next(it, s.size());
-        sexprs.push_back(s);
-    }
-
-    if (sexprs[0].size() != 1 || !matchExprToken(sexprs[0][0], expr, matchDict, unknownDict))
-        return false;   // operator did not match
-    
-    auto it2 = expr->children().begin();
-    size_t argc = 0;
-    if (sexprs.back().front() == "...?")
-    {
-        // unknown relative ellipse match (+ ?a ?b ...?)   
-        // what is b?
-        if (sexprs[1].front().front() == '?' && sexprs.size() == 4 &&
-            matchDict.find(sexprs[1].front()) == matchDict.end())
-        {
-            bool isUnknown = false;
-            const std::string& head = sexprs[1].front();
-            const std::string& rest = sexprs[2].front();
-            auto it = unknownDict.begin();
-            
-            while (it != unknownDict.end())
-            {
-                if (it->first[0] == sexprs[1].front())
-                {
-                    for (auto i : expr->children())
-                    {
-                        bool loop = true;
-                        for (auto j : it->second->children())
-                        {
-                            if (eqvExpr(i, j))
-                            {
-                                // this subexpression
-                                ExprNode* ell = new SyntaxNode("...?");
-                                ExprNode* before = new SyntaxNode("before", ell);
-                                ExprNode* after = new SyntaxNode("after", ell);
-                                bool found = false;
-
-                                for (auto n : expr->children())
-                                {
-                                    if (eqvExpr(n, i))   found = true;
-                                    else if (found)      after->children().push_back(n);
-                                    else                 before->children().push_back(n);
-                                }
-
-                                ell->children().push_back(before);
-                                ell->children().push_back(after);
-                                matchDict[head] = i;
-                                matchDict[rest] = ell;
-
-                                // unknown subexpression
-                                ell = new SyntaxNode("...?");
-                                before = new SyntaxNode("before", ell);
-                                after = new SyntaxNode("after", ell);
-                                found = false;
-
-                                for (auto n : it->second->children())
-                                {
-                                    if (eqvExpr(n, i))  found = true;
-                                    else if (found)     after->children().push_back(n);
-                                    else                before->children().push_back(n);
-                                }
-
-                                ell->children().push_back(before);
-                                ell->children().push_back(after);
-                                matchDict[it->first[1]] = ell;
-
-                                delete it->second;
-                                it = unknownDict.erase(it);
-                                loop = false;
-                                break;
-                            }
-                        }
-
-                        if (!loop) break;
-                    }
-
-                    isUnknown = true;
-                    break;
-                }
-                else
-                {
-                    ++it;
-                }    
-            }
-            
-            if (!isUnknown)
-            {
-                std::vector<std::string> key;   // must be variable followed by an ellipse
-                key.push_back(head);
-                key.push_back(rest);
-
-                ExprNode* ell = new SyntaxNode("...");
-                ell->children().insert(ell->children().begin(), 
-                                       expr->children().begin(),
-                                       expr->children().end());
-                unknownDict[key] = ell;
-                // Any match expr w/ a relative ellipse and a subexpression variable
-                // must be of the form (op ?x ?y ...?), assume true
-                return true;
-            }
-        }
-        else // regular match expressions
-        {
-            ExprNode* ell = new SyntaxNode("...?");
-            ExprNode* before = new SyntaxNode("before", ell);
-            ExprNode* after = new SyntaxNode("after", ell);
-
-            ell->children().push_back(before);
-            ell->children().push_back(after);
-
-            size_t len = expr->children().size();
-            size_t needed = sexprs.size() - 3;
-            size_t check = len - needed;
-            for (size_t idx = 1; argc < check && (idx - 1) < needed; ++argc, ++it2)
-            {
-                if (matchExprHelper(sexprs[idx], *it2, matchDict, unknownDict))
-                {
-                    if (idx == needed)
-                    {
-                        after->children().insert(after->children().begin(),
-                                                 std::next(it2),
-                                                 expr->children().end());
-                        matchDict[sexprs[idx + 1].front()] = ell;
-                        return true;
-                    }
-
-                    ++idx;
-                }
-                else
-                {
-                    before->children().push_back(*it2);
-                }
-            }
-
-            before->children().clear();
-            freeExpression(ell);
-            return false;
-        }
-    }
-    else
-    {
-        for (size_t i = 1; i < sexprs.size(); ++i, ++it2, ++argc)
-        {
-            if (it2 == expr->children().end()) // too many match arguments
-                return false;
-            
-            if (i + 1 < sexprs.size() && sexprs[i + 1].front() == "...")
-            {
-                size_t after = (sexprs.size() - 2) - i;
-                size_t inlist = expr->children().size() - argc - after;
-
-                ExprNode* ell = new SyntaxNode("...");
-                for (size_t j = 0; j < inlist; ++j, ++it2)
-                {
-                    ExprNode* t = *it2;
-                    t->setParent(ell);
-                    ell->children().push_back(t);
-                }
-
-                matchDict[sexprs[i].front()] = ell;
-                argc += (inlist - 1);
-                it2 = std::next(it2, (inlist - 1));
-                ++i;
-            }
-            else
-            {
-                if (!matchExprHelper(sexprs[i], *it2, matchDict, unknownDict))
-                    return false;
-            }
-        }
-
-        if (argc != expr->children().size()) // too few match arguments
-            return false;
-    }
-
-    return true;
-}
-
-void clearMatchDict(std::map<std::string, ExprNode*>& matchDict)
-{
-    for (auto e : matchDict) // clear match dict
-    {
-        if (e.second->toString() == "...?")
-        {
-            delete e.second->children().front();
-            delete e.second->children().back();
-            delete e.second;
-        }
-        else if (e.second->toString() == "...")
-        {
-            delete e.second;
-        }
-    }
-
-    matchDict.clear();
-}
-
-bool matchExpr(const std::string& match, ExprNode* expr,
-               std::map<std::string, ExprNode*>& matchDict)
-{
-    std::vector<std::string> tokens = tokenizeMatchString(match);
-    std::map<std::vector<std::string>, ExprNode*> unknownDict;
-    bool res = matchExprHelper(tokens, expr, matchDict, unknownDict);
-
-    if (!unknownDict.empty())
-        res = false;
-
-    if (!res) // on failure
-    {
-        clearMatchDict(matchDict);
-        for (auto e : unknownDict) // clear unknown dict
-        {
-            if (e.second->toString() == "...")
-                delete e.second;
-        }
-    }
-
-    return res;
-}
-
-bool matchExpr(const std::string& match, ExprNode* expr)
-{
-    std::map<std::string, ExprNode*> matchDict;
-    bool res = matchExpr(match, expr, matchDict);
-    clearMatchDict(matchDict);
-    return res;
-}
-
-ExprNode* buildTreeHelper(const std::vector<std::string> tokens,
-                          const std::map<std::string, ExprNode*>& matchDict)
-{
-    if (tokens.size() == 1)
-    {
-        if (matchDict.find(tokens.front()) != matchDict.end())
-        {
-            if (tokens.front().front() == '?')
-            {
-                ExprNode* t = matchDict.at(tokens.front());
-                return ((t->toString() == "...") ? t : copyOf(t));
-            }
-           
-           return copyNode(matchDict.at(tokens.front()));
-        }
-        
-        std::list<ExprNode*> exprTokens = tokenizeStr(tokens.front());
-        return exprTokens.front();
-    }
-
-    std::vector<std::vector<std::string>> sexprs;
-    auto it = std::next(tokens.begin());
-    auto end = std::prev(tokens.end());
-
-    while (it != end)
-    {
-        std::vector<std::string> s = extractMatchSubexpr(tokens, it);
-        it = std::next(it, s.size());
-        sexprs.push_back(s);
-    }
-    
-    ExprNode* op = buildTreeHelper(sexprs[0], matchDict);
-    op->setParent(nullptr);
-    bool ellipse = sexprs.back().front() == "...?";
-    
-    if (ellipse)
-    {
-        ExprNode* ell = matchDict.at(sexprs[sexprs.size() - 2].front());
-        for (auto e : ell->children().front()->children())
-        {
-            ExprNode* t = copyOf(e);
-            t->setParent(op);
-            op->children().push_back(t);
-        }
-    }
-
-    size_t lim = (ellipse ? (sexprs.size() - 2) : sexprs.size());
-    for (size_t i = 1; i < lim; ++i)
-    {
-        ExprNode* sub = buildTreeHelper(sexprs[i], matchDict);
-        if (sub->toString() == "...") // ellipse match
-        {
-            if (i + 1 == sexprs.size() || sexprs[i + 1].front() != "...")
-            {
-                gErrorManager.log("Expected \"...\" after \"" + sexprs[i].front() + "\" in the match expression",
-                                    ErrorManager::FATAL);
-                return op;
-            }
-
-            for (auto e : sub->children())
-            {
-                ExprNode* t = copyOf(e);
-                t->setParent(op);
-                op->children().push_back(t);
-            }
-
-            ++i; // skip ellipse
-        }
-        else
-        {
-            sub->setParent(op);
-            op->children().push_back(sub);
-        }
-    }
-
-    if (ellipse)
-    {
-        ExprNode* ell = matchDict.at(sexprs[sexprs.size() - 2].front());
-        for (auto e : ell->children().back()->children())
-        {
-            ExprNode* t = copyOf(e);
-            t->setParent(op);
-            op->children().push_back(t);
-        }
-    }
-
-    return op;
-}
-
-ExprNode* buildTree(const std::string& match, const std::map<std::string, ExprNode*>& matchDict)
-{
-    std::vector<std::string> tokens = tokenizeMatchString(match);
-    return buildTreeHelper(tokens, matchDict);
-}
-
-ExprNode* applyMatchTransform(const std::string& input, const std::string& output, ExprNode* expr)
-{
-    std::map<std::string, ExprNode*> matchDict;
-    if (matchExpr(input, expr, matchDict))
-    {
-        ExprNode* ret = buildTree(output, matchDict);
-        clearMatchDict(matchDict);
-        freeExpression(expr);
-        return ret;
-    }
-    else
-    {
-        clearMatchDict(matchDict);
-    }
-
-    return expr;
 }
 
 // ** Unique Transform Matcher ** //
@@ -1005,9 +536,7 @@ ExprNode* UniqueExprMatcher::get(const std::string& key) const
 bool UniqueExprMatcher::match(ExprNode* expr, const std::string& match)
 {
     MatchExpr mexpr(match);
-
-    mSubexprs.clear();
-    return mexpr.match(expr);
+    return mexpr.match(expr, mSubexprs);
 }
 
 }

--- a/lib/expr/matcher.cpp
+++ b/lib/expr/matcher.cpp
@@ -50,7 +50,8 @@ bool isMatchString(const std::string& match)
         }
         else if (e == ")")
         {
-            subexprCount[parenCount] = 0; // reset
+            if (subexprCount[parenCount] == 0)      return false;
+            subexprCount.erase(parenCount);
             --parenCount;
         }
         else
@@ -60,13 +61,6 @@ bool isMatchString(const std::string& match)
     }
 
     if (parenCount != 0)    return false; // unmatched parenthesis
-
-    for (auto it : subexprCount)
-    {
-        if (it.second == 0)     // nullary subexpr
-            return false;
-    }
-
     return true;
 }
 
@@ -213,13 +207,20 @@ ExprNode* applyMatchTransform(const std::string& input, const std::string& outpu
 
 void UniqueTransformMatcher::add(const std::string& input, const std::string& output)
 {
-    if (mTransforms.find(input) != mTransforms.end())
+    if (!isMatchString(input) || !isMatchString(output))
+    {
+        gErrorManager.log("Expected a match transform. Got " + input + " and " + output,
+                          ErrorManager::FATAL);
+    }
+    else if (mTransforms.find(input) != mTransforms.end())
     {
         gErrorManager.log("Overwriting transform " + input + " -> " + mTransforms.at(input) + " with " + output,
                           ErrorManager::WARNING);
     }
-
-    mTransforms[input] = output;
+    else
+    {
+        mTransforms[input] = output;
+    }
 }
 
 ExprNode* UniqueTransformMatcher::transform(ExprNode* expr)

--- a/lib/expr/matcher.cpp
+++ b/lib/expr/matcher.cpp
@@ -209,4 +209,28 @@ ExprNode* applyMatchTransform(const std::string& input, const std::string& outpu
     return ret;
 }
 
+// ** Unique Transform Matcher ** //
+
+void UniqueTransformMatcher::add(const std::string& input, const std::string& output)
+{
+    if (mTransforms.find(input) != mTransforms.end())
+    {
+        gErrorManager.log("Overwriting transform " + input + " -> " + mTransforms.at(input) + " with " + output,
+                          ErrorManager::WARNING);
+    }
+
+    mTransforms[input] = output;
+}
+
+ExprNode* UniqueTransformMatcher::transform(ExprNode* expr)
+{
+    for (auto e : mTransforms)
+    {
+        if (matchExpr(e.first, expr))   // if match, return transform
+            return applyMatchTransform(e.first, e.second, expr);
+    }
+
+    return expr; // else, return unaltered
+}
+
 }

--- a/lib/expr/matcher.cpp
+++ b/lib/expr/matcher.cpp
@@ -7,29 +7,73 @@
 namespace MathSolver
 {
 
-MatchExpr::node_t MatchExpr::buildMatchTree(const std::vector<std::string>& tokens)
+// 
+// MatchDict
+//
+
+void MatchDict::add(const std::string& id, ExprNode* expr)
+{
+    if (mDict.find(id) != mDict.end())
+    {
+        gErrorManager.log("MatchDict: overwriting key \"" + id + "\"",
+                          ErrorManager::WARNING);
+        return;
+    }
+
+    mDict[id] = expr;
+}
+
+ExprNode* MatchDict::get(const std::string& id)
+{
+    auto it = mDict.find(id);
+    if (it != mDict.end())  return it->second;
+    else                    return nullptr;
+}
+
+//
+// MatchExpr
+//
+
+bool MatchExpr::match(ExprNode* expr, MatchDict& dict) const
+{
+    return matchSubexpr(mTop, expr, dict);
+}
+
+bool MatchExpr::match(ExprNode* expr) const
+{
+    MatchDict dict;
+    return match(expr, dict);
+}
+
+void MatchExpr::set(const std::string& match)
+{
+    std::vector<std::string> tokens = tokenizeMatchString(match);
+    mTop = buildMatchTree(tokens);
+}
+
+MatchExpr::node MatchExpr::buildMatchTree(const std::vector<std::string>& tokens) const
 {
     if (tokens.size() == 1)
     {
-        node_t node;
-        node.name = tokens.front();
-        node.expr = nullptr;
-        node.type = ((tokens.front().front() == '?') ? node_t::VARIABLE : node_t::SINGLE);
-        node.depth = 0;
-        return node;
+        node leaf;
+        leaf.name = tokens.front();
+        leaf.expr = nullptr;
+        leaf.type = ((tokens.front().front() == '?') ? node::VARIABLE : node::SINGLE);
+        leaf.depth = 0;
+        return leaf;
     }
     else
     {
         if (tokens.front() != "(" && tokens.front() != ")")
         {
-            gErrorManager.log("Malformed match expression!", ErrorManager::FATAL);
-            return node_t();
+            gErrorManager.log("Expected a subexpression inside parenthesis!", ErrorManager::FATAL);
+            return node();
         }
 
-        node_t top;
+        node top;
         top.name = tokens[1];
         top.expr = nullptr;
-        top.type = node_t::SINGLE;
+        top.type = node::SINGLE;
 
         size_t end = tokens.size() - 1; // end paren
         for (size_t i = 2; i < end; ++i)
@@ -44,20 +88,20 @@ MatchExpr::node_t MatchExpr::buildMatchTree(const std::vector<std::string>& toke
                     else if (tokens[j] == ")")  --paren;
                 }
 
-                std::vector<std::string> sexpr;
-                sexpr.insert(sexpr.begin(), tokens.begin() + i, tokens.begin() + j);
+                std::vector<std::string> sexpr(tokens.begin() + i, tokens.begin() + j);
                 top.children.push_back(buildMatchTree(sexpr));
                 i = j - 1;
             }
-            else if (tokens[i] == "...")
+            else if (tokens[i] == "..." || tokens[i] == "...?")
             {
+                if (i + 1 != end)
+                {
+                    gErrorManager.log("Ellipses can only appear at the end of a subexpression", ErrorManager::FATAL);
+                    return node();
+                }
+
                 top.children.back().depth += 1;
-                top.children.back().type = node_t::ELLIPSE;
-            }
-            else if (tokens[i] == "...?")
-            {
-                top.children.back().depth += 1;
-                top.children.back().type = node_t::REL_ELLIPSE;
+                top.children.back().type = ((tokens[i] == "...") ? node::ELLIPSE : node::REL_ELLIPSE);
             }
             else
             {
@@ -66,23 +110,109 @@ MatchExpr::node_t MatchExpr::buildMatchTree(const std::vector<std::string>& toke
             }
         }
 
-        auto cmp = [](node_t& lhs, node_t& rhs) { return lhs.depth < rhs.depth; };
+        auto cmp = [](node& lhs, node& rhs) { return lhs.depth < rhs.depth; };
         auto it = std::min_element(top.children.begin(), top.children.end(), cmp);
-        top.depth = it->depth + 1;
+        top.depth = it->depth + 1; // min(children) + 1
         return top;
     }
 }
 
-void MatchExpr::set(const std::string& match)
+bool MatchExpr::matchLeaf(const node& match, ExprNode* expr, MatchDict& dict) const
 {
-    if (!isMatchString(match))
+    const std::string& token = match.name;
+    if (token.front() == '?')  // if a variable
     {
-        gErrorManager.log("Expected a match string: " + match, ErrorManager::FATAL);
-        return;
+        auto inDict = dict.get(token);
+        if (inDict != nullptr) return eqvExpr(inDict, expr); // check equivalence
+        
+        MatchDict::ell_dict_t& ellDict = dict.ellDict();
+        dict.add(token, expr); // add to the main dictionary
+
+        auto pred = [&](MatchDict::ell_dict_t::value_type pair) {
+            return pair.first.first == token;
+        };
+
+        auto it = std::find_if(ellDict.begin(), ellDict.end(), pred);
+        if (it != ellDict.end()) // clear from the ellipse dictionary
+        {
+            const std::string& rest = it->first.second;
+
+            ExprNode* ell = new SyntaxNode("...");
+            ExprNode* before = new SyntaxNode("before", ell);
+            ExprNode* after = new SyntaxNode("after", ell);
+
+            ell->children().push_back(before);
+            ell->children().push_back(after);
+
+            bool found = false;
+            for (auto n : it->second->children())
+            {
+                if (eqvExpr(n, expr))   found = true;
+                else if (found)         after->children().push_back(n);
+                else                    before->children().push_back(n);
+            }
+
+            dict.add(rest, ell);    // add rest identifier
+            it = ellDict.erase(it); // remove
+        }
+        
+        return true;
     }
 
-    std::vector<std::string> tokens = tokenizeMatchString(match);
-    mTop = buildMatchTree(tokens);
+    if (dict.get(token) != nullptr)     // check if it's the same
+        return (token == expr->toString());
+
+    dict.add(token, expr);  // add if not found
+    return true;
+}
+
+bool MatchExpr::matchSubexpr(const node& match, ExprNode* expr, MatchDict& dict) const
+{
+    if (match.children.empty()) // leaf
+        return matchLeaf(match, expr, dict);
+    
+    // match subtree
+    if (!matchLeaf(match, expr, dict))
+        return false;
+
+    if (match.children.back().type == node::REL_ELLIPSE)  // (+ 0 ?b ...?)
+    {
+
+    }
+    else if (match.children.back().type == node::ELLIPSE) // (+ ?a ?b ...)
+    {
+        if (match.children.size() > expr->children().size() + 1)
+            return false;  // too many args
+
+        auto it = expr->children().begin();
+        size_t end = match.children.size() - 1;
+        for (size_t i = 0; i < end; ++i)
+        {
+            if (!matchSubexpr(match.children[i], *it, dict))
+                return false;
+            ++it;
+        }
+
+        ExprNode* ell = new SyntaxNode("...");
+        ell->children().insert(ell->children().begin(), it, expr->children().end());
+        for (auto e : ell->children())  e->setParent(ell);  // not necessary, good for debugging
+        dict.add(match.children[end].name, ell);
+    }
+    else
+    {
+        if (match.children.size() != expr->children().size())
+            return false;  // argc does not match
+
+        auto it = expr->children().begin();
+        for (auto e : match.children)
+        {
+            if (!matchSubexpr(e, *it, dict))
+                return false;
+            ++it;
+        }
+    }
+    
+    return true;
 }
 
 std::vector<std::string> tokenizeMatchString(const std::string& match)
@@ -110,13 +240,19 @@ std::vector<std::string> tokenizeMatchString(const std::string& match)
     return tokens;
 }
 
-std::string MatchExpr::toString(const MatchExpr::node_t& node) const
+std::string MatchExpr::toString(const MatchExpr::node& tree) const
 {
-    if (node.depth == 0)    return node.name;
+    if (tree.children.empty())    return tree.name;
 
-    std::string accum = "(" + node.name;
-    for (auto e : node.children)
+    std::string accum = "(" + tree.name;
+    for (auto e : tree.children)
+    {
         accum += (" " + toString(e));
+        if (e.type == node::REL_ELLIPSE)    accum += " ...?";
+        else if (e.type == node::ELLIPSE)   accum += " ...";
+            
+    }
+
     return accum + ")";
 }
 

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -28,7 +28,7 @@ public:
     void clear();
 
     // Returns a pointer the expression associated with id. Returns nullptr on failure.
-    ExprNode* get(const std::string& id);
+    ExprNode* get(const std::string& id) const;
 
     // Returns a reference to the ellipse dictionary.
     inline ell_dict_t& ellDict() { return mEll; }
@@ -61,6 +61,9 @@ public:
     inline MatchExpr() = default;
     inline MatchExpr(const std::string& match) { set(match); }
 
+    // Creates an expression based on this match expression and dictionary.
+    ExprNode* create(const MatchDict& dict) const;
+
     // Returns true if the expression matches. A match dictionary can be optionally
     // passed to store match data.
     bool match(ExprNode* expr, MatchDict& dict) const;
@@ -77,6 +80,12 @@ private:
     // Given a list of match expression tokens, returns the corresponding
     // syntax tree. Called recursively.
     node buildMatchTree(const std::vector<std::string>& tokens) const;
+
+    // Creates a single leaf based on a syntax node.
+    ExprNode* createLeaf(const node& match, const MatchDict& dict) const;
+
+    // Creates a subexpression based on a syntax tree.
+    ExprNode* createSubexpr(const node& match, const MatchDict& dict) const;
 
     // Returns true if the expression matches a single token. Stores match
     // data in a dictionary.
@@ -118,6 +127,8 @@ ExprNode* applyMatchTransform(const std::string& input, const std::string& outpu
 // Useful for matching unique transformations.
 class UniqueExprTransformer
 {
+    typedef std::vector<std::pair<MatchExpr, MatchExpr>> transform_t;
+
 public:
 
     UniqueExprTransformer();   // default constructor
@@ -137,7 +148,7 @@ public:
 
 private:
 
-    std::map<std::string, std::string> mTransforms;
+    transform_t mTransforms;
     bool mSuccess;
 };
 
@@ -155,7 +166,7 @@ public:
 
 private:
 
-    std::map<std::string, ExprNode*> mSubexprs;
+    MatchDict mSubexprs;
 };
 
 }

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -1,0 +1,21 @@
+#ifndef _MATHSOLVER_MATCHER_H_
+#define _MATHSOLVER_MATCHER_H_
+
+#include <list>
+#include <string>
+#include "expr.h"
+
+namespace MathSolver
+{
+
+std::list<std::string> tokenizeMatchString(const std::string& match);
+
+bool matchExpr(const std::string& match, ExprNode* expr);
+
+bool isMatchString(const std::string& match);
+
+ExprNode* applyMatchTransform(const std::string& input, const std::string& output, ExprNode* expr);
+
+}
+
+#endif

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -11,15 +11,42 @@ namespace MathSolver
 
 /* Match helper objects */
 
+class MatchDict
+{
+public:
+
+    typedef std::map<std::string, ExprNode*>                            dict_t;
+    typedef std::map<std::pair<std::string, std::string>, ExprNode*>    ell_dict_t;
+
+    inline MatchDict() = default;
+
+    // Adds a key-value pair to the primary dictionary.
+    void add(const std::string& id, ExprNode* expr);
+
+    // Returns a pointer the expression associated with id. Returns nullptr on failure.
+    ExprNode* get(const std::string& id);
+
+    // Returns a reference to the ellipse dictionary
+    inline ell_dict_t& ellDict() { return mEll; }
+    inline const ell_dict_t& ellDict() const { return mEll; }
+
+private:
+
+    dict_t mDict;       // primary dictionary
+    ell_dict_t mEll;    // ellipse dictionary (temporary storage during matching)
+};
+
 // Stores the syntax tree of a match expression
 class MatchExpr
 {
-    struct node_t
+public:
+
+    struct node
     {
         enum Type { SINGLE, VARIABLE, ELLIPSE, REL_ELLIPSE };
 
         std::string name;
-        std::vector<node_t> children;
+        std::vector<node> children;
         ExprNode* expr;
         Type type;
         int depth;
@@ -27,8 +54,13 @@ class MatchExpr
 
 public:
 
-    inline MatchExpr() {}
+    inline MatchExpr() = default;
     inline MatchExpr(const std::string& match) { set(match); }
+
+    // Returns true if the expression matches. A match dictionary can be optionally
+    // passed to store match data.
+    bool match(ExprNode* expr, MatchDict& dict) const;
+    bool match(ExprNode* expr) const;
 
     // Sets this object based on a match string.
     void set(const std::string& match);
@@ -38,16 +70,24 @@ public:
 
 private:
 
-    // Helper functions. Given a list of match expression tokens, returns the corresponding
+    // Given a list of match expression tokens, returns the corresponding
     // syntax tree. Called recursively.
-    node_t buildMatchTree(const std::vector<std::string>& tokens);
+    node buildMatchTree(const std::vector<std::string>& tokens) const;
+
+    // Returns true if the expression matches a single token. Stores match
+    // data in a dictionary.
+    bool matchLeaf(const node& match, ExprNode* expr, MatchDict& dict) const;
+
+    // Returns true if the expression matches the given syntax tree. Stores
+    // match data in a dictionary
+    bool matchSubexpr(const node& match, ExprNode* expr, MatchDict& dict) const;
 
     // Returns the subtree as a string.
-    std::string toString(const node_t& node) const;
+    std::string toString(const node& tree) const;
 
 private:
 
-    node_t mTop;
+    node mTop;
 };
 
 /* Match helper functions */

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -95,6 +95,10 @@ private:
     // match data in a dictionary
     bool matchSubexpr(const node& match, ExprNode* expr, MatchDict& dict) const;
 
+    // Tokenizes a given match expression and returns the tokens in a vector. Not safe, does not
+    // check if the match expressions is valid.
+    std::vector<std::string> tokenizeMatchString(const std::string& match);
+
     // Returns the subtree as a string.
     std::string toString(const node& tree) const;
 
@@ -102,23 +106,6 @@ private:
 
     node mTop;
 };
-
-/* Match helper functions */
-
-// Tokenizes a given match expression and returns the tokens in a vector. Not safe, does not
-// check if the match expressions is valid.
-std::vector<std::string> tokenizeMatchString(const std::string& match);
-
-// Returns true if the expression matches the match expression and false otherwise. Not safe, does not
-// check if the match expressions is valid.
-bool matchExpr(const std::string& match, ExprNode* expr);
-
-// Returns true if the match expression is valid.
-bool isMatchString(const std::string& match);
-
-// Returns an updated expression by applying the given transformation on an expression. Not safe, does not
-// check if the match expressions are valid or if the expression matches the transformation.
-ExprNode* applyMatchTransform(const std::string& input, const std::string& output, ExprNode* expr);
 
 /* Matchers */
 
@@ -156,6 +143,11 @@ private:
 class UniqueExprMatcher
 {
 public:
+
+    // Clears the dictionary of extraneous nodes. Call this after a successful match when
+    // the subexpression components are no longer of use and before the underlying
+    // expression is altered.
+    inline void clear() { mSubexprs.clear(); }
 
     // Returns the subexpression mapped by the key. Call this only if match returns true.
     ExprNode* get(const std::string& key) const;

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -15,14 +15,15 @@ class MatchDict
 {
 public:
 
-    typedef std::map<std::string, ExprNode*>                            dict_t;
+    typedef std::map<std::string, std::pair<ExprNode*, bool>>           dict_t;
     typedef std::map<std::pair<std::string, std::string>, ExprNode*>    ell_dict_t;
+    typedef std::map<std::string, std::vector<ExprNode*>>               subp_t;
 
     inline MatchDict() = default;
     inline ~MatchDict() { clear(); }
 
     // Adds a key-value pair to the primary dictionary.
-    void add(const std::string& id, ExprNode* expr);
+    void add(const std::string& id, ExprNode* expr, bool pattern = false);
 
     // Deletes extra nodes in this dictionary
     void clear();
@@ -34,10 +35,15 @@ public:
     inline ell_dict_t& ellDict() { return mEll; }
     inline const ell_dict_t& ellDict() const { return mEll; }
 
+    // Returns a reference to the subpattern dictionary.
+    inline subp_t& subp() { return mSubPattern; }
+    inline const subp_t& subp() const { return mSubPattern; }
+
 private:
 
     dict_t mDict;       // primary dictionary
     ell_dict_t mEll;    // ellipse dictionary (temporary storage during matching)
+    subp_t mSubPattern;
 };
 
 // Stores the syntax tree of a match expression
@@ -101,6 +107,9 @@ private:
 
     // Returns the subtree as a string.
     std::string toString(const node& tree) const;
+
+    // Returns a vector of all the variables in a subexpression
+    std::vector<std::string> varsInSubexpr(const node& match) const;
 
 private:
 

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -9,6 +9,46 @@
 namespace MathSolver
 {
 
+/* Match helper objects */
+
+// Stores the syntax tree of a match expression
+class MatchExpr
+{
+    struct node_t
+    {
+        enum Type { SINGLE, VARIABLE, ELLIPSE, REL_ELLIPSE };
+
+        std::string name;
+        std::vector<node_t> children;
+        ExprNode* expr;
+        Type type;
+        int depth;
+    };
+
+public:
+
+    inline MatchExpr() {}
+    inline MatchExpr(const std::string& match) { set(match); }
+
+    // Sets this object based on a match string.
+    void set(const std::string& match);
+
+    // Returns this object as a string.
+    inline std::string toString() const { return toString(mTop); }
+
+private:
+
+    // Helper functions. Given a list of match expression tokens, returns the corresponding
+    // syntax tree. Called recursively.
+    node_t buildMatchTree(const std::vector<std::string>& tokens);
+
+    // Returns the subtree as a string.
+    std::string toString(const node_t& node) const;
+
+private:
+
+    node_t mTop;
+};
 
 /* Match helper functions */
 

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -19,14 +19,18 @@ public:
     typedef std::map<std::pair<std::string, std::string>, ExprNode*>    ell_dict_t;
 
     inline MatchDict() = default;
+    inline ~MatchDict() { clear(); }
 
     // Adds a key-value pair to the primary dictionary.
     void add(const std::string& id, ExprNode* expr);
 
+    // Deletes extra nodes in this dictionary
+    void clear();
+
     // Returns a pointer the expression associated with id. Returns nullptr on failure.
     ExprNode* get(const std::string& id);
 
-    // Returns a reference to the ellipse dictionary
+    // Returns a reference to the ellipse dictionary.
     inline ell_dict_t& ellDict() { return mEll; }
     inline const ell_dict_t& ellDict() const { return mEll; }
 

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -1,6 +1,7 @@
 #ifndef _MATHSOLVER_MATCHER_H_
 #define _MATHSOLVER_MATCHER_H_
 
+#include <map>
 #include <list>
 #include <string>
 #include "expr.h"
@@ -15,6 +16,31 @@ bool matchExpr(const std::string& match, ExprNode* expr);
 bool isMatchString(const std::string& match);
 
 ExprNode* applyMatchTransform(const std::string& input, const std::string& output, ExprNode* expr);
+
+/* Matchers */
+
+// Stores and applies transformations on expressions using expression matching logic
+// Unlike the TransformMatcher, this object will return the first matching expression it encounters.
+// Useful for matching unique transformations.
+class UniqueTransformMatcher
+{
+public:
+
+    // Default constructors
+    // Default destructor
+
+    // Adds a transformation. Both parameters must be match expressions.
+    void add(const std::string& input, const std::string& output);
+
+    // Attempts to apply one of the stored transformations. Returns the updated expression if 
+    // successful or the unaltered expression if not.
+    ExprNode* transform(ExprNode* expr);
+
+private:
+
+    std::map<std::string, std::string> mTransforms;
+    
+};
 
 }
 

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -28,19 +28,22 @@ public:
     // Clears all entries in this dictionary. Deletes extra nodes in this dictionary.
     void clear();
 
+    // Returns a reference to the ellipse dictionary.
+    inline patt_t& ellDict() { return mEll; }
+    inline const patt_t& ellDict() const { return mEll; }
+
     // Returns a pointer the expression associated with id. Returns nullptr on failure.
     ExprNode* get(const std::string& id) const;
 
     // Clears all entries in this dictionary. Does not delete extra nodes!!
     void release();
 
-    // Returns a reference to the ellipse dictionary.
-    inline patt_t& ellDict() { return mEll; }
-    inline const patt_t& ellDict() const { return mEll; }
-
     // Returns a reference to the subpattern dictionary.
     inline subp_t& subp() { return mSubPattern; }
     inline const subp_t& subp() const { return mSubPattern; }
+
+    // Updates a key.
+    void update(const std::string& id, ExprNode* expr, bool pattern = false);
 
 private:
 

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -2,7 +2,7 @@
 #define _MATHSOLVER_MATCHER_H_
 
 #include <map>
-#include <list>
+#include <vector>
 #include <string>
 #include "expr.h"
 
@@ -12,9 +12,9 @@ namespace MathSolver
 
 /* Match helper functions */
 
-// Tokenizes a given match expression and returns the tokens in a list. Not safe, does not
+// Tokenizes a given match expression and returns the tokens in a vector. Not safe, does not
 // check if the match expressions is valid.
-std::list<std::string> tokenizeMatchString(const std::string& match);
+std::vector<std::string> tokenizeMatchString(const std::string& match);
 
 // Returns true if the expression matches the match expression and false otherwise. Not safe, does not
 // check if the match expressions is valid.

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -9,12 +9,22 @@
 namespace MathSolver
 {
 
+
+/* Match helper functions */
+
+// Tokenizes a given match expression and returns the tokens in a list. Not safe, does not
+// check if the match expressions is valid.
 std::list<std::string> tokenizeMatchString(const std::string& match);
 
+// Returns true if the expression matches the match expression and false otherwise. Not safe, does not
+// check if the match expressions is valid.
 bool matchExpr(const std::string& match, ExprNode* expr);
 
+// Returns true if the match expression is valid.
 bool isMatchString(const std::string& match);
 
+// Returns an updated expression by applying the given transformation on an expression. Not safe, does not
+// check if the match expressions are valid or if the expression matches the transformation.
 ExprNode* applyMatchTransform(const std::string& input, const std::string& output, ExprNode* expr);
 
 /* Matchers */
@@ -26,20 +36,39 @@ class UniqueTransformMatcher
 {
 public:
 
-    // Default constructors
-    // Default destructor
+    UniqueTransformMatcher();   // default constructor
 
     // Adds a transformation. Both parameters must be match expressions.
     void add(const std::string& input, const std::string& output);
 
-    // Attempts to apply one of the stored transformations. Returns the updated expression if 
-    // successful or the unaltered expression if not.
+    // Attempts to apply one of the stored transformations. 
     ExprNode* transform(ExprNode* expr);
+
+    // Returns whether or not the last transformation attempt was successful.
+    // Calling this function after initialization returns false.s
+    inline bool success() const;
 
 private:
 
     std::map<std::string, std::string> mTransforms;
-    
+    bool successful;
+};
+
+// Stores a single match expression for matching and a map to access matched subexpressions
+class UniqueExprMatcher
+{
+public:
+
+    // Returns the subexpression mapped by the key. Call this only if match returns true.
+    ExprNode* get(const std::string& key) const;
+
+    // Attempts to match a given expression tree against a match expression.
+    // Returns true on success, returns false otherwise.
+    bool match(ExprNode* expr, const std::string& match);
+
+private:
+
+    std::map<std::string, ExprNode*> mSubexprs;
 };
 
 }

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -32,11 +32,11 @@ ExprNode* applyMatchTransform(const std::string& input, const std::string& outpu
 // Stores and applies transformations on expressions using expression matching logic
 // Unlike the TransformMatcher, this object will return the first matching expression it encounters.
 // Useful for matching unique transformations.
-class UniqueTransformMatcher
+class UniqueExprTransformer
 {
 public:
 
-    UniqueTransformMatcher();   // default constructor
+    UniqueExprTransformer();   // default constructor
 
     // Adds a transformation. Both parameters must be match expressions.
     void add(const std::string& input, const std::string& output);
@@ -48,7 +48,7 @@ public:
     ExprNode* transform(ExprNode* expr);
 
     // Returns whether or not the last transformation attempt was successful.
-    // Calling this function after initialization returns false.s
+    // Calling this function after initialization returns false.
     inline bool success() const { return mSuccess; }
 
 private:

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -41,17 +41,20 @@ public:
     // Adds a transformation. Both parameters must be match expressions.
     void add(const std::string& input, const std::string& output);
 
+    // Clears the map of transforms and resets the success flag.
+    void clear();
+
     // Attempts to apply one of the stored transformations. 
     ExprNode* transform(ExprNode* expr);
 
     // Returns whether or not the last transformation attempt was successful.
     // Calling this function after initialization returns false.s
-    inline bool success() const;
+    inline bool success() const { return mSuccess; }
 
 private:
 
     std::map<std::string, std::string> mTransforms;
-    bool successful;
+    bool mSuccess;
 };
 
 // Stores a single match expression for matching and a map to access matched subexpressions

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -16,7 +16,7 @@ class MatchDict
 public:
 
     typedef std::map<std::string, std::pair<ExprNode*, bool>>           dict_t;
-    typedef std::map<std::pair<std::string, std::string>, ExprNode*>    ell_dict_t;
+    typedef std::map<std::pair<std::string, std::string>, ExprNode*>    patt_t;
     typedef std::map<std::string, std::vector<ExprNode*>>               subp_t;
 
     inline MatchDict() = default;
@@ -32,8 +32,8 @@ public:
     ExprNode* get(const std::string& id) const;
 
     // Returns a reference to the ellipse dictionary.
-    inline ell_dict_t& ellDict() { return mEll; }
-    inline const ell_dict_t& ellDict() const { return mEll; }
+    inline patt_t& ellDict() { return mEll; }
+    inline const patt_t& ellDict() const { return mEll; }
 
     // Returns a reference to the subpattern dictionary.
     inline subp_t& subp() { return mSubPattern; }
@@ -42,7 +42,7 @@ public:
 private:
 
     dict_t mDict;       // primary dictionary
-    ell_dict_t mEll;    // ellipse dictionary (temporary storage during matching)
+    patt_t mEll;    // ellipse dictionary (temporary storage during matching)
     subp_t mSubPattern;
 };
 
@@ -65,10 +65,10 @@ public:
 public:
 
     inline MatchExpr() = default;
-    inline MatchExpr(const std::string& match) { set(match); }
+    inline MatchExpr(const std::string& match, bool permissive = false) { set(match, permissive); }
 
     // Creates an expression based on this match expression and dictionary.
-    ExprNode* create(const MatchDict& dict) const;
+    ExprNode* create(const MatchDict& dict, Transform post) const;
 
     // Returns true if the expression matches. A match dictionary can be optionally
     // passed to store match data.
@@ -76,7 +76,7 @@ public:
     bool match(ExprNode* expr) const;
 
     // Sets this object based on a match string.
-    void set(const std::string& match);
+    void set(const std::string& match, bool permissive = false);
 
     // Returns this object as a string.
     inline std::string toString() const { return toString(mTop); }
@@ -85,13 +85,13 @@ private:
 
     // Given a list of match expression tokens, returns the corresponding
     // syntax tree. Called recursively.
-    node buildMatchTree(const std::vector<std::string>& tokens) const;
+    node buildMatchTree(const std::vector<std::string>& tokens, bool permissive) const;
 
     // Creates a single leaf based on a syntax node.
-    ExprNode* createLeaf(const node& match, const MatchDict& dict) const;
+    ExprNode* createLeaf(const node& match, const MatchDict& dict, bool shallow = false) const;
 
     // Creates a subexpression based on a syntax tree.
-    ExprNode* createSubexpr(const node& match, const MatchDict& dict) const;
+    ExprNode* createSubexpr(const node& match, const MatchDict& dict, Transform post, bool top = false) const;
 
     // Returns true if the expression matches a single token. Stores match
     // data in a dictionary.
@@ -136,7 +136,7 @@ public:
     void clear();
 
     // Attempts to apply one of the stored transformations. 
-    ExprNode* transform(ExprNode* expr);
+    ExprNode* transform(ExprNode* expr, Transform post = [](ExprNode* expr) { return expr; });
 
     // Returns whether or not the last transformation attempt was successful.
     // Calling this function after initialization returns false.

--- a/lib/expr/matcher.h
+++ b/lib/expr/matcher.h
@@ -19,17 +19,20 @@ public:
     typedef std::map<std::pair<std::string, std::string>, ExprNode*>    patt_t;
     typedef std::map<std::string, std::vector<ExprNode*>>               subp_t;
 
-    inline MatchDict() = default;
-    inline ~MatchDict() { clear(); }
+    inline MatchDict() {}               // default constructor
+    inline ~MatchDict() { clear(); }    // destructor
 
     // Adds a key-value pair to the primary dictionary.
     void add(const std::string& id, ExprNode* expr, bool pattern = false);
 
-    // Deletes extra nodes in this dictionary
+    // Clears all entries in this dictionary. Deletes extra nodes in this dictionary.
     void clear();
 
     // Returns a pointer the expression associated with id. Returns nullptr on failure.
     ExprNode* get(const std::string& id) const;
+
+    // Clears all entries in this dictionary. Does not delete extra nodes!!
+    void release();
 
     // Returns a reference to the ellipse dictionary.
     inline patt_t& ellDict() { return mEll; }
@@ -38,6 +41,11 @@ public:
     // Returns a reference to the subpattern dictionary.
     inline subp_t& subp() { return mSubPattern; }
     inline const subp_t& subp() const { return mSubPattern; }
+
+private:
+
+    // Helper. Copies extra nodes from the other dictionary to this one.
+    void copyPrimary(const MatchDict& other);
 
 private:
 
@@ -53,7 +61,7 @@ public:
 
     struct node
     {
-        enum Type { SINGLE, VARIABLE, ELLIPSE, REL_ELLIPSE };
+        enum Type { SINGLE, VARIABLE, ELLIPSE, REL_ELLIPSE, UNORD_ELLIPSE };
 
         std::string name;
         std::vector<node> children;
@@ -100,6 +108,12 @@ private:
     // Returns true if the expression matches the given syntax tree. Stores
     // match data in a dictionary
     bool matchSubexpr(const node& match, ExprNode* expr, MatchDict& dict) const;
+
+    // Attempts to match a range of subexpression children. Returns true on success.
+    bool matchRelativeEllipse(const node& match, ExprNode* expr, MatchDict& dict, size_t start) const;
+
+    // Attempts to match a subexpression with an unordered ellipse.
+    bool matchUnorderedEllipse(const node& match, ExprNode* expr, MatchDict& dict, size_t start) const;
 
     // Tokenizes a given match expression and returns the tokens in a vector. Not safe, does not
     // check if the match expressions is valid.

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -212,6 +212,22 @@ int opPrec(const std::string& str)
 	else												    return 0;
 }
 
+ExprNode* copyNode(ExprNode* node)
+{
+	if (node->type() == ExprNode::SYNTAX) 			return new SyntaxNode(((SyntaxNode*)node)->name(), node->parent());
+	else if (node->type() == ExprNode::OPERATOR) 	return new OpNode(((OpNode*)node)->name(), node->parent());
+	else if (node->type() == ExprNode::FUNCTION) 	return new FuncNode(((FuncNode*)node)->name(), node->parent());
+	else if (node->type() == ExprNode::VARIABLE) 	return new VarNode(((VarNode*)node)->name(), node->parent());
+	else if (node->type() == ExprNode::CONSTANT) 	return new ConstNode(((ConstNode*)node)->name(), node->parent());
+	else if (node->type() == ExprNode::INTEGER) 	return new IntNode(((IntNode*)node)->value(), node->parent());
+	else if (node->type() == ExprNode::FLOAT)		return new FloatNode(((FloatNode*)node)->value(), node->parent());
+	else if (node->type() == ExprNode::RANGE)		return new RangeNode(((RangeNode*)node)->value(), node->parent());
+	else if (node->type() == ExprNode::BOOLEAN)		return new BoolNode(((BoolNode*)node)->value(), node->parent());
+	
+    gErrorManager.log("Should not have executed here", ErrorManager::FATAL, __FILE__, __LINE__);
+    return nullptr;
+}
+
 ExprNode* moveNode(ExprNode* dest, ExprNode* src)
 {
     if (dest != nullptr && src != nullptr && dest != src)

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -214,15 +214,15 @@ int opPrec(const std::string& str)
 
 ExprNode* copyNode(ExprNode* node)
 {
-	if (node->type() == ExprNode::SYNTAX) 			return new SyntaxNode(((SyntaxNode*)node)->name(), node->parent());
-	else if (node->type() == ExprNode::OPERATOR) 	return new OpNode(((OpNode*)node)->name(), node->parent());
-	else if (node->type() == ExprNode::FUNCTION) 	return new FuncNode(((FuncNode*)node)->name(), node->parent());
-	else if (node->type() == ExprNode::VARIABLE) 	return new VarNode(((VarNode*)node)->name(), node->parent());
-	else if (node->type() == ExprNode::CONSTANT) 	return new ConstNode(((ConstNode*)node)->name(), node->parent());
-	else if (node->type() == ExprNode::INTEGER) 	return new IntNode(((IntNode*)node)->value(), node->parent());
-	else if (node->type() == ExprNode::FLOAT)		return new FloatNode(((FloatNode*)node)->value(), node->parent());
-	else if (node->type() == ExprNode::RANGE)		return new RangeNode(((RangeNode*)node)->value(), node->parent());
-	else if (node->type() == ExprNode::BOOLEAN)		return new BoolNode(((BoolNode*)node)->value(), node->parent());
+	if (node->type() == ExprNode::SYNTAX) 		return new SyntaxNode(((SyntaxNode*)node)->name(), node->parent());
+	if (node->type() == ExprNode::OPERATOR) 	return new OpNode(((OpNode*)node)->name(), node->parent());
+	if (node->type() == ExprNode::FUNCTION) 	return new FuncNode(((FuncNode*)node)->name(), node->parent());
+	if (node->type() == ExprNode::VARIABLE) 	return new VarNode(((VarNode*)node)->name(), node->parent());
+	if (node->type() == ExprNode::CONSTANT) 	return new ConstNode(((ConstNode*)node)->name(), node->parent());
+	if (node->type() == ExprNode::INTEGER) 	    return new IntNode(((IntNode*)node)->value(), node->parent());
+	if (node->type() == ExprNode::FLOAT)		return new FloatNode(((FloatNode*)node)->value(), node->parent());
+	if (node->type() == ExprNode::RANGE)		return new RangeNode(((RangeNode*)node)->value(), node->parent());
+	if (node->type() == ExprNode::BOOLEAN)		return new BoolNode(((BoolNode*)node)->value(), node->parent());
 	
     gErrorManager.log("Should not have executed here", ErrorManager::FATAL, __FILE__, __LINE__);
     return nullptr;

--- a/lib/expr/node.cpp
+++ b/lib/expr/node.cpp
@@ -214,15 +214,15 @@ int opPrec(const std::string& str)
 
 ExprNode* copyNode(ExprNode* node)
 {
-	if (node->type() == ExprNode::SYNTAX) 		return new SyntaxNode(((SyntaxNode*)node)->name(), node->parent());
-	if (node->type() == ExprNode::OPERATOR) 	return new OpNode(((OpNode*)node)->name(), node->parent());
-	if (node->type() == ExprNode::FUNCTION) 	return new FuncNode(((FuncNode*)node)->name(), node->parent());
-	if (node->type() == ExprNode::VARIABLE) 	return new VarNode(((VarNode*)node)->name(), node->parent());
-	if (node->type() == ExprNode::CONSTANT) 	return new ConstNode(((ConstNode*)node)->name(), node->parent());
-	if (node->type() == ExprNode::INTEGER) 	    return new IntNode(((IntNode*)node)->value(), node->parent());
-	if (node->type() == ExprNode::FLOAT)		return new FloatNode(((FloatNode*)node)->value(), node->parent());
-	if (node->type() == ExprNode::RANGE)		return new RangeNode(((RangeNode*)node)->value(), node->parent());
-	if (node->type() == ExprNode::BOOLEAN)		return new BoolNode(((BoolNode*)node)->value(), node->parent());
+	if (node->type() == ExprNode::SYNTAX) 		return new SyntaxNode(((SyntaxNode*)node)->name());
+	if (node->type() == ExprNode::OPERATOR) 	return new OpNode(((OpNode*)node)->name());
+	if (node->type() == ExprNode::FUNCTION) 	return new FuncNode(((FuncNode*)node)->name());
+	if (node->type() == ExprNode::VARIABLE) 	return new VarNode(((VarNode*)node)->name());
+	if (node->type() == ExprNode::CONSTANT) 	return new ConstNode(((ConstNode*)node)->name());
+	if (node->type() == ExprNode::INTEGER) 	    return new IntNode(((IntNode*)node)->value());
+	if (node->type() == ExprNode::FLOAT)		return new FloatNode(((FloatNode*)node)->value());
+	if (node->type() == ExprNode::RANGE)		return new RangeNode(((RangeNode*)node)->value());
+	if (node->type() == ExprNode::BOOLEAN)		return new BoolNode(((BoolNode*)node)->value());
 	
     gErrorManager.log("Should not have executed here", ErrorManager::FATAL, __FILE__, __LINE__);
     return nullptr;

--- a/lib/expr/node.h
+++ b/lib/expr/node.h
@@ -388,6 +388,9 @@ int opPrec(const std::string& str);
 // Node manipulation
 //
 
+// Returns a copy of the given node.
+ExprNode* copyNode(ExprNode* node);
+
 // Sets the parent of src to the parent of dest, deletes the original node at dest, and
 // returns the new node at dest. Effectively overwrites dest with src. The node at dest is
 // unusable after this operation

--- a/lib/mathsolver.h
+++ b/lib/mathsolver.h
@@ -11,6 +11,7 @@
 
 #include "expr/arithmetic.h"
 #include "expr/expr.h"
+#include "expr/matcher.h"
 #include "expr/parser.h"
 #include "expr/polynomial.h"
 

--- a/tests/test-arithmetic.cpp
+++ b/tests/test-arithmetic.cpp
@@ -112,10 +112,10 @@ int main()
 			"(a/b)/c",	 		"a/bc",
 			"a/(b/c)",			"ac/b",
 			"(a*b)/(b*c)",		"a/c",
-			"a/(a*b*c)",		"1/bc",
-			"(a*b*c)/a",		"bc",
-			"(a*b)/(a*c*d)",	"b/cd",
-			"(a*b*c)/(a*d)",	"bc/d"
+			"a/(a*b*c)",		"1/b*c",
+			"(a*b*c)/a",		"b*c",
+			"(a*b)/(a*c*d)",	"b/c*d",
+			"(a*b*c)/(a*d)",	"b*c/d"
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);
@@ -129,7 +129,7 @@ int main()
 			"a+b/c*d",			"a+bd/c",
 			"-a+b*c+d", 		"b*c-a+d",
 			"(3a+5a)/5a",		"8/5",
-			"2a/(15*a*b)",		"2/15b"
+			"2*a/(15*a*b)",		"2/15*b"
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);

--- a/tests/test-arithmetic.cpp
+++ b/tests/test-arithmetic.cpp
@@ -130,7 +130,21 @@ int main()
 			"a+b/c*d",			"a+b*d/c",
 			"-a+b*c+d", 		"b*c-a+d",
 			"(3a+5a)/5a",		"8/5",
-			"2*a/(15*a*b)",		"2/15*b"
+			"2*a/(15*a*b)",		"2/15*b",
+		};
+
+		status &= evalExpr(tests, exprs, COUNT);
+	}
+
+	tests.reset("Polynomials");
+	{
+		const size_t COUNT = 4;
+		const std::string exprs[COUNT * 2] = 
+		{ 
+			"3*x*y + 5*z*x + 7*x*w", 	"(3y+5z+7w)x",
+			"3*x*y - 5*z*x - 7*x*w",	"(3y-5z-7w)x",
+			"3*x*y + 5*z*x - 7*x*w",	"(3y+5z-7w)x",
+			"3*x*y - 5*z*x + 7*x*w",	"(3y-5z+7w)x",
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);

--- a/tests/test-arithmetic.cpp
+++ b/tests/test-arithmetic.cpp
@@ -84,18 +84,19 @@ int main()
 
 	tests.reset("*");
 	{
-		const size_t COUNT = 9;
+		const size_t COUNT = 10;
 		const std::string exprs[COUNT * 2] = 
 		{ 
-			"100*1000",		"100000",
-			"3*(a*b)",		"3*a*b",
-			"1*a*1",		"a",
-			"0*x*y",		"0",
-			"-1*x^2",		"-x^2",
-			"(a/b)*(c/d)",	"ac/bd",
-			"a*(1/d)",		"a/d",
-			"2*a+2*b",		"2(a+b)",
-			"2a+a(b)",		"(b+2)a"
+			"100*1000",				"100000",
+			"3*(a*b)",				"3*a*b",
+			"1*a*1",				"a",
+			"0*x*y",				"0",
+			"-1*x^2",				"-x^2",
+			"(a/b)*(c/d)",			"a*c/b*d",
+			"a*(1/d)",				"a/d",
+			"2*a+2*b",				"2(a+b)",
+			"2a+a(b)",				"(b+2)a",
+			"(a/b)*(c/d)*(x/y)",	"a*c*x/y*b*d"
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);
@@ -126,7 +127,7 @@ int main()
 		const size_t COUNT = 4;
 		const std::string exprs[COUNT * 2] = 
 		{ 
-			"a+b/c*d",			"a+bd/c",
+			"a+b/c*d",			"a+b*d/c",
 			"-a+b*c+d", 		"b*c-a+d",
 			"(3a+5a)/5a",		"8/5",
 			"2*a/(15*a*b)",		"2/15*b"
@@ -147,7 +148,7 @@ int main()
 			"(a%n)%n",			"a%n",
 			"(n^2)%n",			"0",
 			"((a%n)+(b%n))%n",	"(a+b)%n",
-			"((a%n)(b%n))%n",	"ab%n",
+			"((a%n)(b%n))%n",	"a*b%n",
 			"11 mod 3",			"2",
 			"a mod n",			"a mod n"
 		};
@@ -164,7 +165,7 @@ int main()
 			"3^4",		"81",
 			"2^-5",		"1/32",
 			"3^-4",		"1/81",
-			"(a^b)^c",	"a^(bc)"
+			"(a^b)^c",	"a^(b*c)"
 		};
 
 		status &= evalExpr(tests, exprs, COUNT);

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -89,6 +89,7 @@ int main()
             for (size_t j = 0; j < MATCH_COUNT; ++j)
             {
                 ExprNode* expr = parseString(exprs[i]);
+                
                 flattenExpr(expr);
                 tests.runTest(bool_to_string(matchExpr(match[j], expr)), expect[i * EXPR_COUNT + j]);
                 freeExpression(expr);

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -117,7 +117,7 @@ int main()
             "(+ (* ?a ?b) ?c)",
             "(+ (* PI E) ?a)",
             "(* 1 ?a ...)",
-            "(* 1 ...?)"
+            "(* 1 ?a ...?)"
         };
 
         std::string expect[EXPR_COUNT * MATCH_COUNT] =
@@ -164,7 +164,7 @@ int main()
             "(* ?a ?a)",        "(^ ?a 2)",
             "(/ ?a 0)",         "undef",
             "(* 1 ?a ...)",     "(* ?a ...)",
-            "(* 1 ...?)",       "(* ...?)"
+            "(* 1 ?a ...?)",    "(* ?a ...?)"
         };
 
         std::string expect[COUNT] =
@@ -192,7 +192,7 @@ int main()
     }
 
     {
-        UniqueTransformMatcher utm;
+        UniqueExprTransformer utm;
         utm.add("(+ ?a ?a)", "(* 2 ?a)");
         utm.add("(* ?a ?a)", "(^ ?a 2)");
         utm.add("(* ?a 0)", "0");

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -121,7 +121,7 @@ int main()
             "(+ ?a ?a)",    "(* 2 ?a)",
             "(* ?a 0)",     "0",
             "(* ?a ?a)",    "(^ ?a 2)",
-            "(* ?a 0)",     "undef"
+            "(/ ?a 0)",     "undef"
         };
         
         std::cout << "Match and replace" << std::endl;
@@ -129,6 +129,32 @@ int main()
         {
             ExprNode* expr = parseString(exprs[i]);
             expr = applyMatchTransform(match[2 * i], match[2 * i + 1], expr);
+            std::cout << toPrefixString(expr) << std::endl;
+            freeExpression(expr);
+        }
+    }
+
+    {
+        UniqueTransformMatcher utm;
+        utm.add("(+ ?a ?a)", "(* 2 ?a)");
+        utm.add("(* ?a ?a)", "(^ ?a 2)");
+        utm.add("(* ?a 0)", "0");
+        utm.add("(/ ?a 0)", "undef");
+
+        const size_t COUNT = 4;
+        std::string exprs[COUNT] =
+        {
+            "x + x",
+            "x * 0",
+            "x * x",
+            "x / 0"
+        };
+
+        std::cout << "Match and replace" << std::endl;
+        for (size_t i = 0; i < COUNT; ++i)
+        {
+            ExprNode* expr = parseString(exprs[i]);
+            expr = utm.transform(expr);
             std::cout << toPrefixString(expr) << std::endl;
             freeExpression(expr);
         }

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -1,0 +1,111 @@
+#include <iostream>
+#include <list>
+#include <string>
+#include "../lib/mathsolver.h"
+#include "../lib/expr/matcher.h"
+#include "../lib/test/test-common.h"
+
+using namespace MathSolver;
+
+std::string bool_to_string(bool x)
+{
+	return std::string((x ? "true" : "false"));
+}
+
+int main()
+{
+    {
+        const size_t COUNT = 3;
+        std::string match[COUNT] =
+        {
+            "(+ ?a ?b)",
+            "(+ (* ?a ?b) ?c)",
+            "(+ (* PI E) ?a)"
+        };
+        
+        for (size_t i = 0; i < COUNT; ++i)
+        {
+            std::list<std::string> tokens = tokenizeMatchString(match[i]);
+            for (auto e : tokens) std::cout << e << " ";
+            std::cout << std::endl;
+        }
+    }
+
+    {
+        const size_t COUNT = 6;
+        std::string match[COUNT] =
+        {
+            "(+ ?a ?b)",
+            "(+ (* ?a ?b) ?c)",
+            "(+ (* PI E) ?a)",
+            "()",
+            "(+ ?a ())",
+            "(+ (* ?a ?b)"
+        };
+        
+        std::cout << "isMatchString?" << std::endl;
+        for (auto e : match)
+            std::cout << bool_to_string(isMatchString(e)) << std::endl;
+    }
+
+    {
+        const size_t EXPR_COUNT = 2;
+        std::string exprs[EXPR_COUNT] =
+        {
+            "x",
+            "3.14"
+        };
+
+        const size_t MATCH_COUNT = 2;
+        std::string match[MATCH_COUNT] =
+        {
+            "x",
+            "?a"
+        };
+        
+        std::cout << "Single token match?" << std::endl;
+        for (size_t i = 0; i < EXPR_COUNT; ++i)
+        {
+            for (size_t j = 0; j < MATCH_COUNT; ++j)
+            {
+                ExprNode* expr = parseString(exprs[i]);
+                std::cout << exprs[i] << " satisfies? " << match[j] << " : " <<
+                    bool_to_string(matchExpr(match[j], expr)) << std::endl;
+                freeExpression(expr);
+            }
+        }
+    }
+
+    {
+        const size_t EXPR_COUNT = 3;
+        std::string exprs[EXPR_COUNT] =
+        {
+            "5 * 3 + 2",
+            "x + y",
+            "PI * E + 10.5"
+        };
+
+        const size_t MATCH_COUNT = 3;
+        std::string match[MATCH_COUNT] =
+        {
+            "(+ ?a ?b)",
+            "(+ (* ?a ?b) ?c)",
+            "(+ (* PI E) ?a)",
+        };
+        
+        std::cout << "Multi token match?" << std::endl;
+        for (size_t i = 0; i < EXPR_COUNT; ++i)
+        {
+            for (size_t j = 0; j < MATCH_COUNT; ++j)
+            {
+                ExprNode* expr = parseString(exprs[i]);
+                bool res = matchExpr(match[j], expr);
+                std::cout << exprs[i] << " satisfies? " << match[j] << " : " << bool_to_string(res) << std::endl;
+                freeExpression(expr);
+            }
+        }
+    }
+
+    return 0;
+
+}

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -106,6 +106,34 @@ int main()
         }
     }
 
+    {
+        const size_t COUNT = 4;
+        std::string exprs[COUNT] =
+        {
+            "x + x",
+            "x * 0",
+            "x * x",
+            "x / 0"
+        };
+
+        std::string match[COUNT * 2] =
+        {
+            "(+ ?a ?a)",    "(* 2 ?a)",
+            "(* ?a 0)",     "0",
+            "(* ?a ?a)",    "(^ ?a 2)",
+            "(* ?a 0)",     "undef"
+        };
+        
+        std::cout << "Match and replace" << std::endl;
+        for (size_t i = 0; i < COUNT; ++i)
+        {
+            ExprNode* expr = parseString(exprs[i]);
+            expr = applyMatchTransform(match[2 * i], match[2 * i + 1], expr);
+            std::cout << toPrefixString(expr) << std::endl;
+            freeExpression(expr);
+        }
+    }
+
     return 0;
 
 }

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -259,7 +259,6 @@ int main()
             tests.runTest(toPrefixString(uem.get("?a")), "(+ a b)");
             tests.runTest(toPrefixString(uem.get("?b")), "(+ c d)");
             tests.runTest(toPrefixString(uem.get("?c")), "(/ e f)");
-            uem.clear();
         }
         else
         {
@@ -273,7 +272,6 @@ int main()
         if (uem.match(expr, "(^ PI ?a)"))
         {
             tests.runTest(toPrefixString(uem.get("?a")), "4");
-            uem.clear();
         }
         else
         {

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -159,7 +159,7 @@ int main()
     }
 
     {
-        const size_t COUNT = 6;
+        const size_t COUNT = 7;
         std::string exprs[COUNT] =
         {
             "x + x",
@@ -167,17 +167,19 @@ int main()
             "x * x",
             "x / 0",
             "1 * 2 * 3 * 4 * 5",
-            "2 * 1 * 3 * 4 * 5"
+            "2 * 1 * 3 * 4 * 5",
+            "x + y + z + (- y)",
         };
 
         std::string match[COUNT * 2] =
         {
-            "(+ ?a ?a)",        "(* 2 ?a)",
-            "(* ?a 0)",         "0",
-            "(* ?a ?a)",        "(^ ?a 2)",
-            "(/ ?a 0)",         "undef",
-            "(* 1 ?a ...)",     "(* ?a ...)",
-            "(* 1 ?a ...?)",    "(* ?a ...?)"
+            "(+ ?a ?a)",                "(* 2 ?a)",
+            "(* ?a 0)",                 "0",
+            "(* ?a ?a)",                "(^ ?a 2)",
+            "(/ ?a 0)",                 "undef",
+            "(* 1 ?a ...)",             "(* ?a ...)",
+            "(* 1 ?a ...?)",            "(* ?a ...?)",
+            "(+ ?a (-* ?a) ?b ...!)",   "(+ ?b ...!)"
         };
 
         std::string expect[COUNT] =
@@ -187,7 +189,8 @@ int main()
             "(^ x 2)",
             "undef",
             "(* 2 3 4 5)",
-            "(* 2 3 4 5)"
+            "(* 2 3 4 5)",
+            "(+ x z)"
         };
         
         TestModule tests("Transformer 1", verbose);

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -253,6 +253,44 @@ int main()
     }
 
     {
+        TestModule tests("Transformer 3");
+
+        const size_t COUNT = 2;
+        std::string transforms[COUNT * 2] =
+        {
+            "(- ?a ?b ...)",        "(+ ?a (-* ?b) ...)",
+            "(+ ?a (-* ?b) ...)",   "(- ?a ?b ...)"
+        };
+        
+        std::string exprs[COUNT] =
+        {
+            "x-y-z-w",
+            "x+(-y)+(-z)+(-w)"
+        };
+
+        std::string expect[COUNT] =
+        {
+            "(+ x (-* y) (-* z) (-* w))",
+            "(- x y z w)"
+        };
+
+        for (size_t i = 0; i < COUNT; ++i)
+        {
+            UniqueExprTransformer utm;
+            utm.add(transforms[2 * i], transforms[2 * i + 1]);
+            
+            ExprNode* expr = parseString(exprs[i]);
+            flattenExpr(expr);
+            expr = utm.transform(expr);
+            tests.runTest(toPrefixString(expr), expect[i]);
+            freeExpression(expr);
+        }
+
+        std::cout << tests.result() << std::endl;
+        status &= tests.status();
+    }
+
+    {
         UniqueExprMatcher uem;
         ExprNode* expr = parseString("(a + b) * (c + d) + (e / f)");
 

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -2,7 +2,6 @@
 #include <list>
 #include <string>
 #include "../lib/mathsolver.h"
-#include "../lib/expr/matcher.h"
 #include "../lib/test/test-common.h"
 
 using namespace MathSolver;
@@ -183,14 +182,16 @@ int main()
         utm.add("(* ?a ?a)", "(^ ?a 2)");
         utm.add("(* ?a 0)", "0");
         utm.add("(/ ?a 0)", "undef");
+        utm.add("(= ?a (* 2 ?a))", "(= 1 ?a)");
 
-        const size_t COUNT = 4;
+        const size_t COUNT = 5;
         std::string exprs[COUNT] =
         {
             "x + x",
             "x * 0",
             "x * x",
-            "x / 0"
+            "x / 0",
+            "x + y = 2 * (x + y)"
         };
 
         std::string expect[COUNT] =
@@ -198,13 +199,15 @@ int main()
             "(* 2 x)",
             "0",
             "(^ x 2)",
-            "undef"
+            "undef",
+            "(= 1 (+ x y))"
         };
 
         TestModule tests("Unique transform matcher", verbose);
         for (size_t i = 0; i < COUNT; ++i)
         {
             ExprNode* expr = parseString(exprs[i]);
+            std::cout << toPrefixString(expr) << std::endl;
             expr = utm.transform(expr);
             tests.runTest(toPrefixString(expr), expect[i]);
             freeExpression(expr);

--- a/tests/test-matcher.cpp
+++ b/tests/test-matcher.cpp
@@ -118,9 +118,9 @@ int main()
 
         std::string expect[EXPR_COUNT * MATCH_COUNT] =
         {
-            "false", "true", "false",
+            "true", "true", "false",
             "true", "false", "false",
-            "false", "true", "true"
+            "true", "true", "true"
         };
         
         TestModule tests("Multi token matching", verbose);
@@ -210,6 +210,41 @@ int main()
             freeExpression(expr);
         }
 
+        std::cout << tests.result() << std::endl;
+        status &= tests.status();
+    }
+
+    {
+        UniqueExprMatcher uem;
+        ExprNode* expr = parseString("(a + b) * (c + d) + (e / f)");
+
+        TestModule tests("Unique expr matcher", verbose);
+        if (uem.match(expr, "(+ (* ?a ?b) ?c)"))
+        {
+            tests.runTest(toPrefixString(uem.get("?a")), "(+ a b)");
+            tests.runTest(toPrefixString(uem.get("?b")), "(+ c d)");
+            tests.runTest(toPrefixString(uem.get("?c")), "(/ e f)");
+        }
+        else
+        {
+            std::cout << "Expression should have matched" << std::endl;
+            status = false;
+        }
+        
+        freeExpression(expr);
+
+        expr = parseString("PI ^ 4");
+        if (uem.match(expr, "(^ PI ?a)"))
+        {
+            tests.runTest(toPrefixString(uem.get("?a")), "4");
+        }
+        else
+        {
+            std::cout << "Expression should have matched" << std::endl;
+            status = false;
+        }
+
+        freeExpression(expr);
         std::cout << tests.result() << std::endl;
         status &= tests.status();
     }


### PR DESCRIPTION
This PR adds objects that can match components of an expression or transform expressions in some way. Up until this point, simplifications had to be hard-coded, manipulating each part of an expression. Now, expressions can be matched and a new expression can be built. Matching features include:
- [x] Matcher (stores subexpression variables)
- [x] Transformer (creates a new expression)
- [x] Absolute pattern variables, ex: (+ 1 2 ?a ...)
- [x] Relative pattern variables, ex: (+ 1 2 ?a ...?)
- [ ] Unordered, relative pattern variables, ex (+ 1 2 ?a ...??)
- [ ] Replace hard-coded transforms during evaluation